### PR TITLE
v6.1.0: Native Ausrücke-Verzögerung, automatische Updates, Design-Fixes

### DIFF
--- a/-Leitstellenspiel-Ausr-cke-Verz-gerung-der-Fahrzeuge.user.js
+++ b/-Leitstellenspiel-Ausr-cke-Verz-gerung-der-Fahrzeuge.user.js
@@ -498,45 +498,54 @@
     // ---------------------------------------------------------------------
     // Styles
     // ---------------------------------------------------------------------
+    // Farben/Look an die dunkle Leitstellenspiel-Oberfläche angelehnt
+    // (dunkle Panels, helle Schrift, blaue Akzentfarbe für Buttons).
     GM_addStyle(`
         #avzToggleButton {
             position: fixed;
             bottom: 20px;
             right: 20px;
-            z-index: 1000;
-            background-color: #007bff;
+            z-index: 10000;
+            background-color: #3b82f6;
             color: #fff;
             border: none;
             padding: 10px 20px;
-            border-radius: 5px;
-            box-shadow: 0 2px 10px rgba(0,0,0,0.2);
+            border-radius: 6px;
+            font-size: 14px;
+            font-weight: bold;
+            box-shadow: 0 2px 12px rgba(0,0,0,0.5);
             cursor: pointer;
         }
         #avzToggleButton:hover {
-            background-color: #0056b3;
+            background-color: #2563eb;
         }
         #vehicleSidebar {
             position: fixed;
             top: 100px;
             right: 10px;
-            width: 350px;
+            width: 360px;
             max-height: 70vh;
             overflow-y: auto;
-            background-color: #f8f9fa;
-            color: #212529;
-            border: 1px solid #ccc;
-            border-radius: 6px;
-            padding: 15px 20px 20px;
-            box-shadow: 0 2px 10px rgba(0,0,0,0.2);
-            z-index: 1000;
+            background-color: #1b1f27;
+            color: #e8e8e8;
+            border: 1px solid rgba(255,255,255,0.12);
+            border-radius: 8px;
+            padding: 16px 20px 20px;
+            box-shadow: 0 8px 30px rgba(0,0,0,0.6);
+            z-index: 10000;
+            font-size: 14px;
         }
         #vehicleSidebar .avz-header {
             display: flex;
             align-items: center;
             justify-content: space-between;
+            border-bottom: 1px solid rgba(255,255,255,0.1);
+            padding-bottom: 10px;
         }
         #vehicleSidebar .avz-header h4 {
             margin: 0;
+            font-size: 16px;
+            color: #fff;
         }
         #avzCloseButton {
             background: none;
@@ -544,59 +553,65 @@
             font-size: 22px;
             line-height: 1;
             cursor: pointer;
-            color: #666;
+            color: #9aa0a6;
         }
         #avzCloseButton:hover {
-            color: #000;
+            color: #fff;
         }
         #vehicleSidebar .avz-hint {
             font-size: 12px;
-            color: #666;
-            margin: 8px 0 12px;
-        }
-        #vehicleSidebar input {
-            margin-bottom: 10px;
+            color: #9aa0a6;
+            margin: 10px 0 14px;
         }
         .btn-primary {
-            background-color: #007bff;
-            border-color: #007bff;
+            background-color: #3b82f6;
+            border-color: #3b82f6;
             padding: 8px 16px;
-            color: white;
-            border-radius: 4px;
-            border: 1px solid #007bff;
+            color: #fff;
+            border-radius: 5px;
+            border: 1px solid #3b82f6;
             cursor: pointer;
+            font-weight: bold;
         }
         .btn-primary:hover {
-            background-color: #0056b3;
-            border-color: #004085;
+            background-color: #2563eb;
+            border-color: #2563eb;
         }
         .avz-feedback {
             display: inline-block;
             margin-left: 10px;
-            color: #28a745;
+            color: #3ddc84;
         }
         .form-group {
-            margin-bottom: 15px;
+            margin-bottom: 14px;
         }
         .form-group label {
             display: block;
             font-weight: bold;
+            color: #cfd3d8;
+            margin-bottom: 4px;
         }
         .form-group input {
             width: 100%;
             padding: 8px;
-            border: 1px solid #ccc;
-            border-radius: 4px;
+            background-color: #11141a;
+            color: #fff;
+            border: 1px solid #3a3f4b;
+            border-radius: 5px;
             box-sizing: border-box;
+        }
+        .form-group input:focus {
+            outline: none;
+            border-color: #3b82f6;
         }
         .avz-countdown-badge {
             display: inline-flex;
             align-items: center;
             gap: 6px;
             font-size: 12px;
-            color: #856404;
-            background-color: #fff3cd;
-            border: 1px solid #ffeeba;
+            color: #ffcf5c;
+            background-color: rgba(255, 193, 7, 0.12);
+            border: 1px solid rgba(255, 193, 7, 0.4);
             border-radius: 4px;
             padding: 2px 6px;
             margin-left: 4px;
@@ -618,19 +633,19 @@
             bottom: 70px;
             right: 20px;
             max-width: 320px;
-            z-index: 1001;
+            z-index: 10001;
             padding: 10px 14px;
-            border-radius: 5px;
+            border-radius: 6px;
             font-size: 13px;
-            box-shadow: 0 2px 10px rgba(0,0,0,0.25);
+            box-shadow: 0 4px 16px rgba(0,0,0,0.5);
             color: #fff;
         }
         .avz-toast-info {
-            background-color: #007bff;
+            background-color: #3b82f6;
         }
         .avz-toast-warning {
             background-color: #e0a800;
-            color: #212529;
+            color: #1b1f27;
         }
         .avz-toast-error {
             background-color: #dc3545;

--- a/-Leitstellenspiel-Ausr-cke-Verz-gerung-der-Fahrzeuge.user.js
+++ b/-Leitstellenspiel-Ausr-cke-Verz-gerung-der-Fahrzeuge.user.js
@@ -1,13 +1,11 @@
 // ==UserScript==
 // @name         Leitstellenspiel Ausrücke-Verzögerung für einzelne Wache
 // @namespace    https://www.leitstellenspiel.de/
-// @version      4.1.0
+// @version      5.0.0
 // @description  Zeigt Fahrzeuge der aktuellen Wache, ermöglicht die Konfiguration einer Ausrückverzögerung pro Fahrzeug und verzögert das tatsächliche Alarmieren im Spiel um die eingestellte Zeit.
 // @author       Hudnur111 - IBoy - Coding Crew Tag 1
-// @match        https://www.leitstellenspiel.de/buildings/*
-// @match        https://leitstellenspiel.de/buildings/*
-// @match        https://www.leitstellenspiel.de/missions/*
-// @match        https://leitstellenspiel.de/missions/*
+// @match        https://www.leitstellenspiel.de/*
+// @match        https://leitstellenspiel.de/*
 // @icon         https://cdn-icons-png.flaticon.com/512/3135/3135715.png
 // @license      GPL-3.0-or-later
 // @grant        GM_addStyle
@@ -29,7 +27,7 @@
     // Skriptinformationen / Update-Check
     // ---------------------------------------------------------------------
     const SCRIPT_NAME = 'Leitstellenspiel Ausrücke-Verzögerung für einzelne Wache';
-    const CURRENT_VERSION = '4.1.0';
+    const CURRENT_VERSION = '5.0.0';
     const UPDATE_URL = 'https://github.com/Hudnur111/-Leitstellenspiel-Ausr-cke-Verz-gerung-der-Fahrzeuge.user.js/raw/main/-Leitstellenspiel-Ausr-cke-Verz-gerung-der-Fahrzeuge.user.js';
     const VERSION_URL = 'https://raw.githubusercontent.com/Hudnur111/-Leitstellenspiel-Ausr-cke-Verz-gerung-der-Fahrzeuge/main/version.txt';
     const UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000; // alle 6 Stunden, nicht bei jedem Seitenaufruf
@@ -130,14 +128,23 @@
     }
 
     // ---------------------------------------------------------------------
-    // Sidebar zur Konfiguration der Verzögerungen (nur auf /buildings/*)
+    // Sidebar zur Konfiguration der Verzögerungen
+    //
+    // Leitstellenspiel öffnet Wachen/Fahrzeuge als AJAX-Overlay, OHNE die
+    // Browser-URL zu wechseln - `window.location.pathname` bleibt dabei
+    // unverändert. Die aktuell angezeigte Wache lässt sich daher nicht aus
+    // der URL bestimmen, sondern nur aus dem sichtbaren Seiteninhalt: der
+    // Name der Wache (z.B. "THW Schwäbisch Gmünd") wird als Überschrift
+    // angezeigt und mit den Fahrzeug-/Gebäudedaten aus der API abgeglichen.
     // ---------------------------------------------------------------------
     const VEHICLE_ENDPOINTS = ['/api/vehicles', '/api/vehicles.json'];
+    const BUILDING_ENDPOINTS = ['/api/buildings', '/api/buildings.json'];
     const BUILDING_ID_FIELDS = ['building_id', 'caserne_id', 'station_id'];
+    const INDEX_CACHE_TTL_MS = 60 * 1000;
 
-    async function fetchAlleFahrzeuge() {
+    async function fetchJsonList(endpoints) {
         let lastError = null;
-        for (const url of VEHICLE_ENDPOINTS) {
+        for (const url of endpoints) {
             try {
                 const response = await fetch(url, {
                     credentials: 'same-origin',
@@ -151,61 +158,71 @@
                 if (Array.isArray(data)) return data;
                 if (data && Array.isArray(data.result)) return data.result;
                 if (data && Array.isArray(data.vehicles)) return data.vehicles;
+                if (data && Array.isArray(data.buildings)) return data.buildings;
                 lastError = new Error(`${url} → unerwartetes Antwortformat: ${JSON.stringify(data).slice(0, 200)}`);
             } catch (error) {
                 lastError = error;
             }
         }
-        throw lastError || new Error('Kein Fahrzeug-Endpunkt konnte erreicht werden.');
+        throw lastError || new Error(`Keiner der Endpunkte (${endpoints.join(', ')}) konnte erreicht werden.`);
+    }
+
+    let vehiclesIndexCache = null;
+    let vehiclesIndexCacheAt = 0;
+    async function getVehiclesIndex(forceRefresh = false) {
+        if (!forceRefresh && vehiclesIndexCache && (Date.now() - vehiclesIndexCacheAt) < INDEX_CACHE_TTL_MS) {
+            return vehiclesIndexCache;
+        }
+        vehiclesIndexCache = await fetchJsonList(VEHICLE_ENDPOINTS);
+        vehiclesIndexCacheAt = Date.now();
+        debugLog(`${vehiclesIndexCache.length} Fahrzeuge von der API geladen.`);
+        return vehiclesIndexCache;
+    }
+
+    let buildingsIndexCache = null;
+    let buildingsIndexCacheAt = 0;
+    async function getBuildingsIndex(forceRefresh = false) {
+        if (!forceRefresh && buildingsIndexCache && (Date.now() - buildingsIndexCacheAt) < INDEX_CACHE_TTL_MS) {
+            return buildingsIndexCache;
+        }
+        buildingsIndexCache = await fetchJsonList(BUILDING_ENDPOINTS);
+        buildingsIndexCacheAt = Date.now();
+        debugLog(`${buildingsIndexCache.length} Gebäude von der API geladen.`);
+        return buildingsIndexCache;
     }
 
     function findBuildingIdField(fahrzeuge) {
         return BUILDING_ID_FIELDS.find(field => fahrzeuge.some(fz => fz[field] !== undefined));
     }
 
-    async function loadFahrzeuge() {
-        const match = window.location.pathname.match(/^\/buildings\/(\d+)/);
-        if (!match) return;
-        const wacheId = Number(match[1]);
-
-        try {
-            const alleFahrzeuge = await fetchAlleFahrzeuge();
-            debugLog(`${alleFahrzeuge.length} Fahrzeuge insgesamt von der API erhalten.`);
-
-            const buildingField = findBuildingIdField(alleFahrzeuge);
-            let fahrzeuge;
-            if (buildingField) {
-                fahrzeuge = alleFahrzeuge.filter(fz => Number(fz[buildingField]) === wacheId);
-            } else {
-                // Feldname unbekannt/abweichend: lieber alle Fahrzeuge zeigen
-                // als das Skript unsichtbar nichts tun zu lassen.
-                showToast(
-                    'Ausrückverzögerung: Wache konnte nicht anhand der Fahrzeugdaten gefiltert werden - zeige alle Fahrzeuge. Bitte melden!',
-                    'warning',
-                    10000
-                );
-                fahrzeuge = alleFahrzeuge;
-            }
-
-            fahrzeuge = fahrzeuge.slice().sort((a, b) => (a.caption || '').localeCompare(b.caption || ''));
-
-            if (fahrzeuge.length === 0) {
-                showToast(
-                    `Ausrückverzögerung: Keine Fahrzeuge für Wache ${wacheId} gefunden (von ${alleFahrzeuge.length} insgesamt).`,
-                    'warning',
-                    8000
-                );
-                return;
-            }
-
-            createSidebar(fahrzeuge);
-        } catch (error) {
-            console.error(`[${SCRIPT_NAME}] Fehler beim Laden der Fahrzeuge:`, error);
-            showToast(`Ausrückverzögerung: Fahrzeuge konnten nicht geladen werden (${error.message}).`, 'error', 12000);
+    // Sucht unter allen Überschriften-ähnlichen Elementen der Seite nach
+    // einem Text, der exakt dem "caption"-Feld eines Eintrags entspricht.
+    // Robuster als das Raten von CSS-Klassen, da der Name im Spiel immer
+    // sichtbar als Überschrift/Titel angezeigt wird.
+    function findEntityByVisibleCaption(entities) {
+        if (!entities || entities.length === 0) return null;
+        const captionMap = new Map();
+        entities.forEach(entity => {
+            if (entity.caption) captionMap.set(entity.caption.trim(), entity);
+        });
+        const headingEls = document.querySelectorAll('h1, h2, h3, h4, .modal-title, .panel-title, .box-title, strong');
+        for (const el of headingEls) {
+            const text = el.textContent.trim();
+            if (text && captionMap.has(text)) return captionMap.get(text);
         }
+        return null;
     }
 
-    function createSidebar(fahrzeuge) {
+    const sidebarState = {
+        toggleButton: null,
+        sidebar: null,
+        fahrzeugList: null,
+        currentBuildingId: null
+    };
+
+    function ensureSidebarShell() {
+        if (sidebarState.sidebar) return sidebarState;
+
         const toggleButton = document.createElement('button');
         toggleButton.id = 'avzToggleButton';
         toggleButton.type = 'button';
@@ -217,7 +234,7 @@
         sidebar.style.display = 'none';
         sidebar.innerHTML = `
             <div class="avz-header">
-                <h4>Fahrzeug-Ausrück-Verzögerung</h4>
+                <h4 id="avzSidebarTitle">Fahrzeug-Ausrück-Verzögerung</h4>
                 <button type="button" id="avzCloseButton" aria-label="Schließen">&times;</button>
             </div>
             <p class="avz-hint">Verzögerung in Sekunden je Fahrzeug. Bei 0 wird sofort alarmiert.</p>
@@ -227,9 +244,27 @@
         `;
         document.body.appendChild(sidebar);
 
-        const fahrzeugList = sidebar.querySelector('#fahrzeugVerzoegerungList');
+        sidebar.querySelector('#avzCloseButton').addEventListener('click', () => {
+            sidebar.style.display = 'none';
+        });
+        toggleButton.addEventListener('click', () => {
+            sidebar.style.display = (sidebar.style.display === 'none') ? 'block' : 'none';
+        });
 
-        fahrzeuge.forEach(fz => {
+        sidebarState.toggleButton = toggleButton;
+        sidebarState.sidebar = sidebar;
+        sidebarState.fahrzeugList = sidebar.querySelector('#fahrzeugVerzoegerungList');
+        return sidebarState;
+    }
+
+    function populateSidebar(building, fahrzeuge) {
+        const { sidebar, fahrzeugList } = ensureSidebarShell();
+        sidebar.querySelector('#avzSidebarTitle').textContent = `Ausrück-Verzögerung: ${building.caption}`;
+        fahrzeugList.innerHTML = '';
+
+        const sorted = fahrzeuge.slice().sort((a, b) => (a.caption || '').localeCompare(b.caption || ''));
+
+        sorted.forEach(fz => {
             const label = fz.vehicle_type_caption || fz.caption || `Fahrzeug #${fz.id}`;
             const fzItem = document.createElement('div');
             fzItem.className = 'form-group';
@@ -253,21 +288,14 @@
             fahrzeugList.appendChild(fzItem);
         });
 
-        sidebar.querySelector('#saveDelays').addEventListener('click', () => saveDelays(fahrzeuge));
-        sidebar.querySelector('#avzCloseButton').addEventListener('click', () => {
-            sidebar.style.display = 'none';
-        });
-
-        toggleButton.addEventListener('click', () => {
-            sidebar.style.display = (sidebar.style.display === 'none') ? 'block' : 'none';
-        });
-
-        fahrzeugList.addEventListener('keypress', (e) => {
+        const saveButton = sidebar.querySelector('#saveDelays');
+        saveButton.onclick = () => saveDelays(sorted);
+        fahrzeugList.onkeypress = (e) => {
             if (e.key === 'Enter' && e.target.classList.contains('delayInput')) {
                 e.preventDefault();
-                saveDelays(fahrzeuge);
+                saveDelays(sorted);
             }
-        });
+        };
     }
 
     function saveDelays(fahrzeuge) {
@@ -283,46 +311,108 @@
         setTimeout(() => { feedback.style.display = 'none'; }, 2000);
     }
 
+    // Wird von der Alarmieren-Erkennung (weiter unten) genutzt, falls sich
+    // die Fahrzeug-ID nicht direkt aus der Tabellenzeile des geklickten
+    // Buttons ableiten lässt (z.B. auf der Einzelfahrzeug-Ansicht, auf der
+    // alle "Alarmieren"-Buttons zum selben, aktuell angezeigten Fahrzeug
+    // gehören).
+    let currentVehicleIdGuess = null;
+
+    // Wird bei jeder relevanten DOM-Änderung erneut ausgeführt, um zu
+    // erkennen, ob gerade eine Wache oder ein Fahrzeug angezeigt wird -
+    // da sich weder URL noch ein "Seitenwechsel"-Event dafür eignen.
+    async function refreshForCurrentView() {
+        try {
+            const vehicles = await getVehiclesIndex();
+            const currentVehicle = findEntityByVisibleCaption(vehicles);
+            currentVehicleIdGuess = currentVehicle ? currentVehicle.id : null;
+
+            const buildings = await getBuildingsIndex();
+            const building = findEntityByVisibleCaption(buildings);
+            if (!building || building.id === sidebarState.currentBuildingId) return;
+
+            const buildingField = findBuildingIdField(vehicles);
+            let fahrzeuge;
+            if (buildingField) {
+                fahrzeuge = vehicles.filter(fz => Number(fz[buildingField]) === Number(building.id));
+            } else {
+                showToast(
+                    'Ausrückverzögerung: Wache konnte nicht anhand der Fahrzeugdaten gefiltert werden - zeige alle Fahrzeuge. Bitte melden!',
+                    'warning',
+                    10000
+                );
+                fahrzeuge = vehicles;
+            }
+
+            if (fahrzeuge.length === 0) {
+                showToast(
+                    `Ausrückverzögerung: Keine Fahrzeuge für Wache "${building.caption}" gefunden.`,
+                    'warning',
+                    8000
+                );
+                return;
+            }
+
+            populateSidebar(building, fahrzeuge);
+            sidebarState.currentBuildingId = building.id;
+            debugLog(`Wache erkannt: ${building.caption} (#${building.id}), ${fahrzeuge.length} Fahrzeuge.`);
+        } catch (error) {
+            debugLog('Fehler bei refreshForCurrentView:', error);
+        }
+    }
+
+    function debounce(fn, waitMs) {
+        let timeoutId = null;
+        return (...args) => {
+            clearTimeout(timeoutId);
+            timeoutId = setTimeout(() => fn(...args), waitMs);
+        };
+    }
+
     // ---------------------------------------------------------------------
     // Ausrück-Interceptor: verzögert das tatsächliche Alarmieren
     //
-    // Leitstellenspiel kennt serverseitig keine Ausrückverzögerung - das
-    // Spiel löst die Alarmierung eines Fahrzeugs über einen AJAX-Link
-    // (Rails-UJS, `data-remote="true"`) auf `/vehicles/<id>/...` aus, z.B.
-    // beim Rückalarmieren `/vehicles/<id>/backalarm?return=mission`. Der
-    // Interceptor fängt den Klick auf einen solchen Alarmieren-Link ab,
-    // zeigt einen Countdown an und löst den echten Klick erst danach aus,
-    // damit Rails-UJS die Anfrage wie gewohnt verarbeitet.
+    // Leitstellenspiel kennt serverseitig keine Ausrückverzögerung. Der im
+    // Spiel sichtbare "Alarmieren"-Button (grüner Button je Einsatz in der
+    // Fahrzeug-Detailansicht) wird per Klick auf den exakten Button-Text
+    // erkannt - das ist zuverlässiger als ein geratener Link-/Href-Aufbau,
+    // da der Text im Spiel-UI stabil sichtbar ist. Die zugehörige
+    // Fahrzeug-ID wird zuerst aus der Tabellenzeile des Buttons abgeleitet
+    // (falls dort ein Link auf /vehicles/<id> existiert) und andernfalls
+    // aus dem aktuell erkannten Fahrzeug der Einzelansicht übernommen.
     //
-    // Hinweis: Ohne Zugriff auf einen eingeloggten Testaccount konnte der
-    // exakte href-Aufbau des "Alarmieren"-Links nicht live verifiziert
-    // werden. Greift die Erkennung nicht, passiert nichts Schädliches -
-    // das Fahrzeug rückt einfach ohne Verzögerung aus wie bisher. Über
-    // `window.__lssAvzDebug = true` in der Konsole lässt sich mitloggen,
-    // welche Links erkannt/ignoriert werden, um den Selektor bei Bedarf
-    // anzupassen.
+    // `window.__lssAvzDebug = true` in der Konsole loggt mit, welche
+    // Klicks erkannt/ignoriert werden.
     // ---------------------------------------------------------------------
-    const pendingLinks = new WeakSet();
-    const bypassLinks = new WeakSet();
-
-    function extractVehicleId(href) {
-        const match = href.match(/\/vehicles\/(\d+)/);
-        return match ? match[1] : null;
-    }
-
-    function isDispatchLink(link) {
-        if (!(link instanceof HTMLAnchorElement)) return false;
-        const href = link.getAttribute('href') || '';
-        if (!/\/vehicles\/\d+/.test(href)) return false;
-        if (/backalarm|zurueck|recall/i.test(href)) return false; // Rückalarmierung ausschließen
-        return /alarm/i.test(href);
-    }
+    const ALARM_BUTTON_TEXT = /^alarmieren!?$/i;
+    const pendingButtons = new WeakSet();
+    const bypassButtons = new WeakSet();
 
     function debugLog(...args) {
         if (window.__lssAvzDebug) console.log(`[${SCRIPT_NAME}]`, ...args);
     }
 
-    function showCountdownBadge(link, seconds, onCancel) {
+    function isAlarmButton(el) {
+        if (!el || !(el instanceof HTMLElement)) return false;
+        if (!['A', 'BUTTON', 'INPUT'].includes(el.tagName)) return false;
+        const text = (el.tagName === 'INPUT' ? el.value : el.textContent).trim();
+        return ALARM_BUTTON_TEXT.test(text);
+    }
+
+    function resolveVehicleIdForButton(button) {
+        const row = button.closest('tr, li, .row, [data-vehicle-id]');
+        if (row) {
+            if (row.dataset && row.dataset.vehicleId) return row.dataset.vehicleId;
+            const link = row.querySelector('a[href*="/vehicles/"]');
+            if (link) {
+                const match = (link.getAttribute('href') || '').match(/\/vehicles\/(\d+)/);
+                if (match) return match[1];
+            }
+        }
+        return currentVehicleIdGuess;
+    }
+
+    function showCountdownBadge(button, seconds, onCancel) {
         const badge = document.createElement('span');
         badge.className = 'avz-countdown-badge';
         let remaining = seconds;
@@ -334,7 +424,7 @@
         cancelBtn.textContent = 'Abbrechen';
         badge.appendChild(cancelBtn);
 
-        link.insertAdjacentElement('afterend', badge);
+        button.insertAdjacentElement('afterend', badge);
 
         const interval = setInterval(() => {
             remaining -= 1;
@@ -358,22 +448,22 @@
     }
 
     document.addEventListener('click', (event) => {
-        const link = event.target.closest('a');
-        if (!link) return;
+        const button = event.target.closest('a, button, input[type="submit"], input[type="button"]');
+        if (!button) return;
 
-        if (bypassLinks.has(link)) {
-            bypassLinks.delete(link);
-            debugLog('Verzögerter Klick wird durchgelassen:', link.href);
+        if (bypassButtons.has(button)) {
+            bypassButtons.delete(button);
+            debugLog('Verzögerter Klick wird durchgelassen:', button);
             return; // Diesen Klick unverändert durchlassen (echte Alarmierung)
         }
 
-        if (!isDispatchLink(link)) {
-            debugLog('Kein Alarmieren-Link, ignoriert:', link.getAttribute('href'));
+        if (!isAlarmButton(button)) return;
+
+        const vehicleId = resolveVehicleIdForButton(button);
+        if (!vehicleId) {
+            debugLog('Alarmieren-Button erkannt, aber keine Fahrzeug-ID ableitbar:', button);
             return;
         }
-
-        const vehicleId = extractVehicleId(link.getAttribute('href') || '');
-        if (!vehicleId) return;
 
         const delay = getDelaySeconds(vehicleId);
         if (delay <= 0) {
@@ -381,8 +471,7 @@
             return;
         }
 
-        if (pendingLinks.has(link)) {
-            // Bereits ein Countdown für diesen Link aktiv - weiteren Klick ignorieren
+        if (pendingButtons.has(button)) {
             event.preventDefault();
             event.stopImmediatePropagation();
             return;
@@ -390,21 +479,21 @@
 
         event.preventDefault();
         event.stopImmediatePropagation();
-        pendingLinks.add(link);
+        pendingButtons.add(button);
         debugLog(`Fahrzeug ${vehicleId}: Alarmierung wird um ${delay}s verzögert.`);
 
         const timeoutId = setTimeout(() => {
-            pendingLinks.delete(link);
-            bypassLinks.add(link);
-            link.click();
+            pendingButtons.delete(button);
+            bypassButtons.add(button);
+            button.click();
         }, delay * 1000);
 
-        showCountdownBadge(link, delay, () => {
+        showCountdownBadge(button, delay, () => {
             clearTimeout(timeoutId);
-            pendingLinks.delete(link);
+            pendingButtons.delete(button);
             debugLog(`Fahrzeug ${vehicleId}: Verzögerte Alarmierung abgebrochen.`);
         });
-    }, true); // Capture-Phase: läuft vor dem Rails-UJS-Handler des Spiels
+    }, true); // Capture-Phase: läuft vor dem Klick-Handler des Spiels
 
     // ---------------------------------------------------------------------
     // Styles
@@ -550,7 +639,14 @@
 
     migrateLegacyDelays();
     checkForUpdate();
-    loadFahrzeuge();
+
+    // Da Wachen/Fahrzeuge als AJAX-Overlay ohne URL-Wechsel angezeigt
+    // werden, gibt es kein "Seite geladen"-Ereignis dafür - stattdessen
+    // wird bei jeder DOM-Änderung (debounced) neu geprüft, ob gerade eine
+    // Wache oder ein Fahrzeug sichtbar ist.
+    const debouncedRefresh = debounce(refreshForCurrentView, 400);
+    new MutationObserver(debouncedRefresh).observe(document.body, { childList: true, subtree: true });
+    refreshForCurrentView();
 
     // Bestätigt, dass das Skript auf dieser Seite überhaupt injiziert und
     // ausgeführt wurde. Bleibt diese Meldung aus, greift das @match nicht

--- a/-Leitstellenspiel-Ausr-cke-Verz-gerung-der-Fahrzeuge.user.js
+++ b/-Leitstellenspiel-Ausr-cke-Verz-gerung-der-Fahrzeuge.user.js
@@ -1,17 +1,16 @@
 // ==UserScript==
 // @name         Leitstellenspiel Ausrücke-Verzögerung für einzelne Wache
 // @namespace    https://www.leitstellenspiel.de/
-// @version      5.0.0
+// @version      5.1.0
 // @description  Zeigt Fahrzeuge der aktuellen Wache, ermöglicht die Konfiguration einer Ausrückverzögerung pro Fahrzeug und verzögert das tatsächliche Alarmieren im Spiel um die eingestellte Zeit.
 // @author       Hudnur111 - IBoy - Coding Crew Tag 1
 // @match        https://www.leitstellenspiel.de/*
 // @match        https://leitstellenspiel.de/*
 // @icon         https://cdn-icons-png.flaticon.com/512/3135/3135715.png
 // @license      GPL-3.0-or-later
+// @updateURL    https://raw.githubusercontent.com/Hudnur111/-Leitstellenspiel-Ausr-cke-Verz-gerung-der-Fahrzeuge.user.js/main/-Leitstellenspiel-Ausr-cke-Verz-gerung-der-Fahrzeuge.user.js
+// @downloadURL  https://raw.githubusercontent.com/Hudnur111/-Leitstellenspiel-Ausr-cke-Verz-gerung-der-Fahrzeuge.user.js/main/-Leitstellenspiel-Ausr-cke-Verz-gerung-der-Fahrzeuge.user.js
 // @grant        GM_addStyle
-// @grant        GM_notification
-// @grant        GM_xmlhttpRequest
-// @connect      raw.githubusercontent.com
 // @run-at       document-idle
 // ==/UserScript==
 
@@ -24,51 +23,17 @@
     window.__lssAusrueckverzoegerungLoaded = true;
 
     // ---------------------------------------------------------------------
-    // Skriptinformationen / Update-Check
+    // Skriptinformationen
+    //
+    // Automatische Updates laufen über die @updateURL/@downloadURL-Angaben
+    // im Header (Tampermonkey-Bordmittel): der Manager prüft von sich aus
+    // periodisch, ob sich @version in der main-Branch-Datei erhöht hat,
+    // und installiert die neue Fassung automatisch. Ein eigener
+    // GM_xmlhttpRequest-Check ist dafür nicht nötig (der bisherige zeigte
+    // zudem auf eine nicht existierende version.txt und lief nie).
     // ---------------------------------------------------------------------
     const SCRIPT_NAME = 'Leitstellenspiel Ausrücke-Verzögerung für einzelne Wache';
-    const CURRENT_VERSION = '5.0.0';
-    const UPDATE_URL = 'https://github.com/Hudnur111/-Leitstellenspiel-Ausr-cke-Verz-gerung-der-Fahrzeuge.user.js/raw/main/-Leitstellenspiel-Ausr-cke-Verz-gerung-der-Fahrzeuge.user.js';
-    const VERSION_URL = 'https://raw.githubusercontent.com/Hudnur111/-Leitstellenspiel-Ausr-cke-Verz-gerung-der-Fahrzeuge/main/version.txt';
-    const UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000; // alle 6 Stunden, nicht bei jedem Seitenaufruf
-    const LAST_CHECK_KEY = 'lss_avz_last_update_check';
-
-    function checkForUpdate() {
-        if (typeof GM_xmlhttpRequest !== 'function') return;
-
-        const lastCheck = Number(localStorage.getItem(LAST_CHECK_KEY) || 0);
-        if (Date.now() - lastCheck < UPDATE_CHECK_INTERVAL_MS) return;
-        localStorage.setItem(LAST_CHECK_KEY, String(Date.now()));
-
-        GM_xmlhttpRequest({
-            method: 'GET',
-            url: VERSION_URL,
-            onload(response) {
-                if (response.status === 200) {
-                    const latestVersion = response.responseText.trim();
-                    if (latestVersion && latestVersion !== CURRENT_VERSION) {
-                        notifyUserForUpdate(latestVersion);
-                    }
-                } else {
-                    console.warn(`[${SCRIPT_NAME}] Versionsprüfung fehlgeschlagen: ${response.status} ${response.statusText}`);
-                }
-            },
-            onerror() {
-                console.warn(`[${SCRIPT_NAME}] Versionsprüfung: Server nicht erreichbar.`);
-            }
-        });
-    }
-
-    function notifyUserForUpdate(latestVersion) {
-        if (typeof GM_notification !== 'function') return;
-        GM_notification({
-            text: `${SCRIPT_NAME} (Version ${latestVersion}) ist verfügbar. Jetzt aktualisieren!`,
-            title: 'Neue Version verfügbar',
-            onclick() {
-                window.open(UPDATE_URL, '_blank');
-            }
-        });
-    }
+    const CURRENT_VERSION = '5.1.0';
 
     // ---------------------------------------------------------------------
     // Sichtbare Status-/Fehlermeldungen. Fehler beim Laden der Fahrzeuge
@@ -653,7 +618,6 @@
     `);
 
     migrateLegacyDelays();
-    checkForUpdate();
 
     // Da Wachen/Fahrzeuge als AJAX-Overlay ohne URL-Wechsel angezeigt
     // werden, gibt es kein "Seite geladen"-Ereignis dafür - stattdessen

--- a/-Leitstellenspiel-Ausr-cke-Verz-gerung-der-Fahrzeuge.user.js
+++ b/-Leitstellenspiel-Ausr-cke-Verz-gerung-der-Fahrzeuge.user.js
@@ -1,11 +1,13 @@
 // ==UserScript==
 // @name         Leitstellenspiel Ausrücke-Verzögerung für einzelne Wache
 // @namespace    https://www.leitstellenspiel.de/
-// @version      4.0.0
+// @version      4.1.0
 // @description  Zeigt Fahrzeuge der aktuellen Wache, ermöglicht die Konfiguration einer Ausrückverzögerung pro Fahrzeug und verzögert das tatsächliche Alarmieren im Spiel um die eingestellte Zeit.
 // @author       Hudnur111 - IBoy - Coding Crew Tag 1
 // @match        https://www.leitstellenspiel.de/buildings/*
+// @match        https://leitstellenspiel.de/buildings/*
 // @match        https://www.leitstellenspiel.de/missions/*
+// @match        https://leitstellenspiel.de/missions/*
 // @icon         https://cdn-icons-png.flaticon.com/512/3135/3135715.png
 // @license      GPL-3.0-or-later
 // @grant        GM_addStyle
@@ -27,7 +29,7 @@
     // Skriptinformationen / Update-Check
     // ---------------------------------------------------------------------
     const SCRIPT_NAME = 'Leitstellenspiel Ausrücke-Verzögerung für einzelne Wache';
-    const CURRENT_VERSION = '4.0.0';
+    const CURRENT_VERSION = '4.1.0';
     const UPDATE_URL = 'https://github.com/Hudnur111/-Leitstellenspiel-Ausr-cke-Verz-gerung-der-Fahrzeuge.user.js/raw/main/-Leitstellenspiel-Ausr-cke-Verz-gerung-der-Fahrzeuge.user.js';
     const VERSION_URL = 'https://raw.githubusercontent.com/Hudnur111/-Leitstellenspiel-Ausr-cke-Verz-gerung-der-Fahrzeuge/main/version.txt';
     const UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000; // alle 6 Stunden, nicht bei jedem Seitenaufruf
@@ -71,6 +73,25 @@
     }
 
     // ---------------------------------------------------------------------
+    // Sichtbare Status-/Fehlermeldungen. Fehler beim Laden der Fahrzeuge
+    // liefen bisher nur in die Browser-Konsole und blieben für die meisten
+    // Nutzer unsichtbar - dadurch wirkte das Skript, als würde es "nicht
+    // mit dem Spiel verbinden", obwohl der eigentliche Fehler erkennbar
+    // gewesen wäre. Ab sofort erscheint jede relevante Meldung auch direkt
+    // auf der Seite.
+    // ---------------------------------------------------------------------
+    function showToast(message, type = 'info', timeoutMs = 6000) {
+        const toast = document.createElement('div');
+        toast.className = `avz-toast avz-toast-${type}`;
+        toast.textContent = message;
+        document.body.appendChild(toast);
+        if (timeoutMs > 0) {
+            setTimeout(() => toast.remove(), timeoutMs);
+        }
+        return toast;
+    }
+
+    // ---------------------------------------------------------------------
     // Verzögerungs-Speicher (localStorage, da das Spiel selbst keine
     // Ausrückverzögerung kennt - diese wird ausschließlich clientseitig
     // durch dieses Skript simuliert)
@@ -111,32 +132,76 @@
     // ---------------------------------------------------------------------
     // Sidebar zur Konfiguration der Verzögerungen (nur auf /buildings/*)
     // ---------------------------------------------------------------------
+    const VEHICLE_ENDPOINTS = ['/api/vehicles', '/api/vehicles.json'];
+    const BUILDING_ID_FIELDS = ['building_id', 'caserne_id', 'station_id'];
+
+    async function fetchAlleFahrzeuge() {
+        let lastError = null;
+        for (const url of VEHICLE_ENDPOINTS) {
+            try {
+                const response = await fetch(url, {
+                    credentials: 'same-origin',
+                    headers: { Accept: 'application/json' }
+                });
+                if (!response.ok) {
+                    lastError = new Error(`${url} → HTTP ${response.status} ${response.statusText}`);
+                    continue;
+                }
+                const data = await response.json();
+                if (Array.isArray(data)) return data;
+                if (data && Array.isArray(data.result)) return data.result;
+                if (data && Array.isArray(data.vehicles)) return data.vehicles;
+                lastError = new Error(`${url} → unerwartetes Antwortformat: ${JSON.stringify(data).slice(0, 200)}`);
+            } catch (error) {
+                lastError = error;
+            }
+        }
+        throw lastError || new Error('Kein Fahrzeug-Endpunkt konnte erreicht werden.');
+    }
+
+    function findBuildingIdField(fahrzeuge) {
+        return BUILDING_ID_FIELDS.find(field => fahrzeuge.some(fz => fz[field] !== undefined));
+    }
+
     async function loadFahrzeuge() {
         const match = window.location.pathname.match(/^\/buildings\/(\d+)/);
         if (!match) return;
         const wacheId = Number(match[1]);
 
         try {
-            const response = await fetch('/api/vehicles', { credentials: 'same-origin' });
-            if (!response.ok) throw new Error(`Fehler beim Abrufen der Fahrzeuge: ${response.status} ${response.statusText}`);
+            const alleFahrzeuge = await fetchAlleFahrzeuge();
+            debugLog(`${alleFahrzeuge.length} Fahrzeuge insgesamt von der API erhalten.`);
 
-            const alleFahrzeuge = await response.json();
-            if (!Array.isArray(alleFahrzeuge)) {
-                throw new Error('Unerwartetes Antwortformat der Fahrzeug-API.');
+            const buildingField = findBuildingIdField(alleFahrzeuge);
+            let fahrzeuge;
+            if (buildingField) {
+                fahrzeuge = alleFahrzeuge.filter(fz => Number(fz[buildingField]) === wacheId);
+            } else {
+                // Feldname unbekannt/abweichend: lieber alle Fahrzeuge zeigen
+                // als das Skript unsichtbar nichts tun zu lassen.
+                showToast(
+                    'Ausrückverzögerung: Wache konnte nicht anhand der Fahrzeugdaten gefiltert werden - zeige alle Fahrzeuge. Bitte melden!',
+                    'warning',
+                    10000
+                );
+                fahrzeuge = alleFahrzeuge;
             }
 
-            const fahrzeuge = alleFahrzeuge
-                .filter(fz => Number(fz.building_id) === wacheId)
-                .sort((a, b) => (a.caption || '').localeCompare(b.caption || ''));
+            fahrzeuge = fahrzeuge.slice().sort((a, b) => (a.caption || '').localeCompare(b.caption || ''));
 
             if (fahrzeuge.length === 0) {
-                console.info(`[${SCRIPT_NAME}] Keine Fahrzeuge für Wache ${wacheId} gefunden.`);
+                showToast(
+                    `Ausrückverzögerung: Keine Fahrzeuge für Wache ${wacheId} gefunden (von ${alleFahrzeuge.length} insgesamt).`,
+                    'warning',
+                    8000
+                );
                 return;
             }
 
             createSidebar(fahrzeuge);
         } catch (error) {
             console.error(`[${SCRIPT_NAME}] Fehler beim Laden der Fahrzeuge:`, error);
+            showToast(`Ausrückverzögerung: Fahrzeuge konnten nicht geladen werden (${error.message}).`, 'error', 12000);
         }
     }
 
@@ -459,9 +524,37 @@
         .avz-countdown-cancel:hover {
             background: #b02a37;
         }
+        .avz-toast {
+            position: fixed;
+            bottom: 70px;
+            right: 20px;
+            max-width: 320px;
+            z-index: 1001;
+            padding: 10px 14px;
+            border-radius: 5px;
+            font-size: 13px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.25);
+            color: #fff;
+        }
+        .avz-toast-info {
+            background-color: #007bff;
+        }
+        .avz-toast-warning {
+            background-color: #e0a800;
+            color: #212529;
+        }
+        .avz-toast-error {
+            background-color: #dc3545;
+        }
     `);
 
     migrateLegacyDelays();
     checkForUpdate();
     loadFahrzeuge();
+
+    // Bestätigt, dass das Skript auf dieser Seite überhaupt injiziert und
+    // ausgeführt wurde. Bleibt diese Meldung aus, greift das @match nicht
+    // (falsche Domain/Pfad) oder der UserScript-Manager blockiert das
+    // Skript - unabhängig von allen anderen Fehlern hier im Code.
+    showToast(`Ausrückverzögerung v${CURRENT_VERSION} geladen.`, 'info', 4000);
 })();

--- a/-Leitstellenspiel-Ausr-cke-Verz-gerung-der-Fahrzeuge.user.js
+++ b/-Leitstellenspiel-Ausr-cke-Verz-gerung-der-Fahrzeuge.user.js
@@ -1,8 +1,8 @@
 // ==UserScript==
 // @name         Leitstellenspiel Ausrücke-Verzögerung für einzelne Wache
 // @namespace    https://www.leitstellenspiel.de/
-// @version      5.1.0
-// @description  Zeigt Fahrzeuge der aktuellen Wache, ermöglicht die Konfiguration einer Ausrückverzögerung pro Fahrzeug und verzögert das tatsächliche Alarmieren im Spiel um die eingestellte Zeit.
+// @version      6.0.0
+// @description  Zeigt alle Fahrzeuge der aktuellen Wache in einer Sidebar und ermöglicht das komfortable Bearbeiten der nativen "Ausrücke-Verzögerung" für alle Fahrzeuge an einer Stelle.
 // @author       Hudnur111 - IBoy - Coding Crew Tag 1
 // @match        https://www.leitstellenspiel.de/*
 // @match        https://leitstellenspiel.de/*
@@ -33,7 +33,7 @@
     // zudem auf eine nicht existierende version.txt und lief nie).
     // ---------------------------------------------------------------------
     const SCRIPT_NAME = 'Leitstellenspiel Ausrücke-Verzögerung für einzelne Wache';
-    const CURRENT_VERSION = '5.1.0';
+    const CURRENT_VERSION = '6.0.0';
 
     // ---------------------------------------------------------------------
     // Sichtbare Status-/Fehlermeldungen. Fehler beim Laden der Fahrzeuge
@@ -54,42 +54,87 @@
         return toast;
     }
 
+    function debugLog(...args) {
+        if (window.__lssAvzDebug) console.log(`[${SCRIPT_NAME}]`, ...args);
+    }
+
     // ---------------------------------------------------------------------
-    // Verzögerungs-Speicher (localStorage, da das Spiel selbst keine
-    // Ausrückverzögerung kennt - diese wird ausschließlich clientseitig
-    // durch dieses Skript simuliert)
+    // Native Ausrücke-Verzögerung
+    //
+    // Wichtige Korrektur gegenüber v5.x: Leitstellenspiel hat dieses
+    // Feature bereits eingebaut ("Ausrücke-Verzögerung" auf der
+    // Fahrzeug-Bearbeiten-Seite, /vehicles/<id>/edit) - das Skript muss
+    // also nicht selbst irgendetwas verzögern, sondern nur bequem dieses
+    // native Feld für alle Fahrzeuge einer Wache an einer Stelle
+    // konfigurierbar machen. Dazu wird die echte Bearbeiten-Seite im
+    // Hintergrund abgerufen, das Feld anhand seines sichtbaren Labels
+    // gefunden (nicht anhand eines geratenen Feldnamens) und das
+    // Formular mit geändertem Wert erneut abgeschickt - alle anderen
+    // Felder (Personenanzahl, Arbeitszeiten, ...) bleiben dabei unangetastet,
+    // da sie unverändert aus dem echten Formular übernommen werden.
     // ---------------------------------------------------------------------
-    const DELAY_KEY_PREFIX = 'lss_avz_delay_v1_';
-    const LEGACY_KEY_PREFIX = 'verzögerung-';
     const MAX_DELAY_SECONDS = 900; // Sicherheitsobergrenze: 15 Minuten
+    const DELAY_LABEL_TEXT = /ausrücke-?verzögerung/i;
 
-    // Alte, unpräfixte Keys (Version <= 3.1) einmalig übernehmen, damit
-    // bestehende Einstellungen der Nutzer nicht verloren gehen.
-    function migrateLegacyDelays() {
-        for (let i = localStorage.length - 1; i >= 0; i--) {
-            const key = localStorage.key(i);
-            if (!key || !key.startsWith(LEGACY_KEY_PREFIX)) continue;
-            const vehicleId = key.slice(LEGACY_KEY_PREFIX.length);
-            const newKey = DELAY_KEY_PREFIX + vehicleId;
-            if (localStorage.getItem(newKey) === null) {
-                localStorage.setItem(newKey, localStorage.getItem(key));
+    function vehicleEditUrl(vehicleId) {
+        return `/vehicles/${vehicleId}/edit`;
+    }
+
+    function findDelayInput(doc) {
+        const labels = doc.querySelectorAll('label');
+        for (const label of labels) {
+            if (!DELAY_LABEL_TEXT.test(label.textContent || '')) continue;
+            const forId = label.getAttribute('for');
+            if (forId) {
+                const input = doc.getElementById(forId);
+                if (input) return input;
             }
-            localStorage.removeItem(key);
+            const container = label.closest('div') || label.parentElement;
+            const input = container && container.querySelector('input[type="number"], input[type="text"]');
+            if (input) return input;
         }
+        return null;
     }
 
-    function getDelaySeconds(vehicleId) {
-        const raw = localStorage.getItem(DELAY_KEY_PREFIX + vehicleId);
-        const value = Number.parseInt(raw, 10);
-        if (!Number.isFinite(value) || value < 0) return 0;
-        return Math.min(value, MAX_DELAY_SECONDS);
+    async function fetchVehicleEditDoc(vehicleId) {
+        const response = await fetch(vehicleEditUrl(vehicleId), {
+            credentials: 'same-origin',
+            headers: { Accept: 'text/html' }
+        });
+        if (!response.ok) {
+            throw new Error(`Bearbeiten-Seite für Fahrzeug ${vehicleId}: HTTP ${response.status}`);
+        }
+        const html = await response.text();
+        return new DOMParser().parseFromString(html, 'text/html');
     }
 
-    function setDelaySeconds(vehicleId, delay) {
-        const value = Number.parseInt(delay, 10);
-        const clamped = Number.isFinite(value) && value > 0 ? Math.min(value, MAX_DELAY_SECONDS) : 0;
-        localStorage.setItem(DELAY_KEY_PREFIX + vehicleId, String(clamped));
-        return clamped;
+    async function readNativeDelay(vehicleId) {
+        const doc = await fetchVehicleEditDoc(vehicleId);
+        const input = findDelayInput(doc);
+        if (!input) throw new Error('"Ausrücke-Verzögerung"-Feld nicht gefunden');
+        const value = Number.parseInt(input.value, 10);
+        return Number.isFinite(value) ? value : 0;
+    }
+
+    async function writeNativeDelay(vehicleId, seconds) {
+        const doc = await fetchVehicleEditDoc(vehicleId);
+        const input = findDelayInput(doc);
+        if (!input || !input.name) throw new Error('"Ausrücke-Verzögerung"-Feld nicht gefunden');
+        const form = input.closest('form');
+        if (!form) throw new Error('Formular für die Fahrzeug-Bearbeitung nicht gefunden');
+
+        const formData = new FormData(form);
+        formData.set(input.name, String(seconds));
+
+        const action = form.getAttribute('action') || `/vehicles/${vehicleId}`;
+        const response = await fetch(action, {
+            method: 'POST', // Rails-Formulare senden PATCH/PUT per _method-Feld immer als POST
+            credentials: 'same-origin',
+            body: formData
+        });
+        if (!response.ok) {
+            throw new Error(`Speichern fehlgeschlagen: HTTP ${response.status}`);
+        }
     }
 
     // ---------------------------------------------------------------------
@@ -202,7 +247,7 @@
                 <h4 id="avzSidebarTitle">Fahrzeug-Ausrück-Verzögerung</h4>
                 <button type="button" id="avzCloseButton" aria-label="Schließen">&times;</button>
             </div>
-            <p class="avz-hint">Verzögerung in Sekunden je Fahrzeug. Bei 0 wird sofort alarmiert.</p>
+            <p class="avz-hint">Ausrücke-Verzögerung in Sekunden je Fahrzeug (native Spiel-Einstellung). Bei 0 rückt das Fahrzeug sofort aus.</p>
             <div id="fahrzeugVerzoegerungList"></div>
             <button class="btn btn-primary" id="saveDelays">Speichern</button>
             <span id="saveFeedback" class="avz-feedback" style="display:none;">Verzögerungen erfolgreich gespeichert!</span>
@@ -222,7 +267,7 @@
         return sidebarState;
     }
 
-    function populateSidebar(building, fahrzeuge) {
+    async function populateSidebar(building, fahrzeuge) {
         const { sidebar, fahrzeugList } = ensureSidebarShell();
         sidebar.querySelector('#avzSidebarTitle').textContent = `Ausrück-Verzögerung: ${building.caption}`;
         fahrzeugList.innerHTML = '';
@@ -244,8 +289,8 @@
             input.id = `avz-fz-${fz.id}`;
             input.min = '0';
             input.max = String(MAX_DELAY_SECONDS);
-            input.placeholder = 'Verzögerung in Sekunden';
-            input.value = String(getDelaySeconds(fz.id));
+            input.placeholder = 'Lädt...';
+            input.disabled = true;
             input.dataset.vehicleId = String(fz.id);
 
             fzItem.appendChild(labelEl);
@@ -261,37 +306,66 @@
                 saveDelays(sorted);
             }
         };
-    }
 
-    function saveDelays(fahrzeuge) {
-        fahrzeuge.forEach(fz => {
+        // Aktuelle Werte kommen von der echten Fahrzeug-Bearbeiten-Seite -
+        // parallel pro Fahrzeug nachladen, damit das Panel nicht blockiert.
+        await Promise.all(sorted.map(async fz => {
             const input = document.getElementById(`avz-fz-${fz.id}`);
             if (!input) return;
-            const clamped = setDelaySeconds(fz.id, input.value);
-            input.value = String(clamped);
-        });
-
-        const feedback = document.getElementById('saveFeedback');
-        feedback.style.display = 'inline';
-        setTimeout(() => { feedback.style.display = 'none'; }, 2000);
+            try {
+                const value = await readNativeDelay(fz.id);
+                input.value = String(value);
+                input.dataset.loadedValue = String(value);
+            } catch (error) {
+                input.placeholder = 'Fehler';
+                debugLog(`Ausrücke-Verzögerung für Fahrzeug ${fz.id} konnte nicht gelesen werden:`, error);
+            } finally {
+                input.disabled = false;
+            }
+        }));
     }
 
-    // Wird von der Alarmieren-Erkennung (weiter unten) genutzt, falls sich
-    // die Fahrzeug-ID nicht direkt aus der Tabellenzeile des geklickten
-    // Buttons ableiten lässt (z.B. auf der Einzelfahrzeug-Ansicht, auf der
-    // alle "Alarmieren"-Buttons zum selben, aktuell angezeigten Fahrzeug
-    // gehören).
-    let currentVehicleIdGuess = null;
+    async function saveDelays(fahrzeuge) {
+        const changed = fahrzeuge
+            .map(fz => ({ fz, input: document.getElementById(`avz-fz-${fz.id}`) }))
+            .filter(({ input }) => input && !input.disabled && input.value !== input.dataset.loadedValue);
+
+        if (changed.length === 0) {
+            showToast('Ausrückverzögerung: Keine Änderungen zum Speichern.', 'info', 3000);
+            return;
+        }
+
+        const results = await Promise.allSettled(changed.map(async ({ fz, input }) => {
+            const clamped = Math.min(Math.max(Number.parseInt(input.value, 10) || 0, 0), MAX_DELAY_SECONDS);
+            await writeNativeDelay(fz.id, clamped);
+            input.value = String(clamped);
+            input.dataset.loadedValue = String(clamped);
+        }));
+
+        const failed = results.filter(r => r.status === 'rejected');
+        if (failed.length > 0) {
+            failed.forEach(r => debugLog('Speichern fehlgeschlagen:', r.reason));
+            showToast(
+                `Ausrückverzögerung: ${failed.length} von ${changed.length} Fahrzeugen konnten nicht gespeichert werden.`,
+                'error',
+                8000
+            );
+        }
+        const succeeded = changed.length - failed.length;
+        if (succeeded > 0) {
+            const feedback = document.getElementById('saveFeedback');
+            feedback.textContent = `${succeeded} Fahrzeug(e) gespeichert!`;
+            feedback.style.display = 'inline';
+            setTimeout(() => { feedback.style.display = 'none'; }, 2500);
+        }
+    }
 
     // Wird bei jeder relevanten DOM-Änderung erneut ausgeführt, um zu
-    // erkennen, ob gerade eine Wache oder ein Fahrzeug angezeigt wird -
-    // da sich weder URL noch ein "Seitenwechsel"-Event dafür eignen.
+    // erkennen, ob gerade eine Wache angezeigt wird - da sich weder URL
+    // noch ein "Seitenwechsel"-Event dafür eignen.
     async function refreshForCurrentView() {
         try {
             const vehicles = await getVehiclesIndex();
-            const currentVehicle = findEntityByVisibleCaption(vehicles);
-            currentVehicleIdGuess = currentVehicle ? currentVehicle.id : null;
-
             const buildings = await getBuildingsIndex();
             const building = findEntityByVisibleCaption(buildings);
             if (!building || building.id === sidebarState.currentBuildingId) return;
@@ -333,132 +407,6 @@
             timeoutId = setTimeout(() => fn(...args), waitMs);
         };
     }
-
-    // ---------------------------------------------------------------------
-    // Ausrück-Interceptor: verzögert das tatsächliche Alarmieren
-    //
-    // Leitstellenspiel kennt serverseitig keine Ausrückverzögerung. Der im
-    // Spiel sichtbare "Alarmieren"-Button (grüner Button je Einsatz in der
-    // Fahrzeug-Detailansicht) wird per Klick auf den exakten Button-Text
-    // erkannt - das ist zuverlässiger als ein geratener Link-/Href-Aufbau,
-    // da der Text im Spiel-UI stabil sichtbar ist. Die zugehörige
-    // Fahrzeug-ID wird zuerst aus der Tabellenzeile des Buttons abgeleitet
-    // (falls dort ein Link auf /vehicles/<id> existiert) und andernfalls
-    // aus dem aktuell erkannten Fahrzeug der Einzelansicht übernommen.
-    //
-    // `window.__lssAvzDebug = true` in der Konsole loggt mit, welche
-    // Klicks erkannt/ignoriert werden.
-    // ---------------------------------------------------------------------
-    const ALARM_BUTTON_TEXT = /^alarmieren!?$/i;
-    const pendingButtons = new WeakSet();
-    const bypassButtons = new WeakSet();
-
-    function debugLog(...args) {
-        if (window.__lssAvzDebug) console.log(`[${SCRIPT_NAME}]`, ...args);
-    }
-
-    function isAlarmButton(el) {
-        if (!el || !(el instanceof HTMLElement)) return false;
-        if (!['A', 'BUTTON', 'INPUT'].includes(el.tagName)) return false;
-        const text = (el.tagName === 'INPUT' ? el.value : el.textContent).trim();
-        return ALARM_BUTTON_TEXT.test(text);
-    }
-
-    function resolveVehicleIdForButton(button) {
-        const row = button.closest('tr, li, .row, [data-vehicle-id]');
-        if (row) {
-            if (row.dataset && row.dataset.vehicleId) return row.dataset.vehicleId;
-            const link = row.querySelector('a[href*="/vehicles/"]');
-            if (link) {
-                const match = (link.getAttribute('href') || '').match(/\/vehicles\/(\d+)/);
-                if (match) return match[1];
-            }
-        }
-        return currentVehicleIdGuess;
-    }
-
-    function showCountdownBadge(button, seconds, onCancel) {
-        const badge = document.createElement('span');
-        badge.className = 'avz-countdown-badge';
-        let remaining = seconds;
-        badge.textContent = ` (Ausrücken in ${remaining}s) `;
-
-        const cancelBtn = document.createElement('button');
-        cancelBtn.type = 'button';
-        cancelBtn.className = 'avz-countdown-cancel';
-        cancelBtn.textContent = 'Abbrechen';
-        badge.appendChild(cancelBtn);
-
-        button.insertAdjacentElement('afterend', badge);
-
-        const interval = setInterval(() => {
-            remaining -= 1;
-            badge.firstChild.textContent = ` (Ausrücken in ${Math.max(remaining, 0)}s) `;
-        }, 1000);
-
-        cancelBtn.addEventListener('click', (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            clearInterval(interval);
-            badge.remove();
-            onCancel();
-        });
-
-        return {
-            remove() {
-                clearInterval(interval);
-                badge.remove();
-            }
-        };
-    }
-
-    document.addEventListener('click', (event) => {
-        const button = event.target.closest('a, button, input[type="submit"], input[type="button"]');
-        if (!button) return;
-
-        if (bypassButtons.has(button)) {
-            bypassButtons.delete(button);
-            debugLog('Verzögerter Klick wird durchgelassen:', button);
-            return; // Diesen Klick unverändert durchlassen (echte Alarmierung)
-        }
-
-        if (!isAlarmButton(button)) return;
-
-        const vehicleId = resolveVehicleIdForButton(button);
-        if (!vehicleId) {
-            debugLog('Alarmieren-Button erkannt, aber keine Fahrzeug-ID ableitbar:', button);
-            return;
-        }
-
-        const delay = getDelaySeconds(vehicleId);
-        if (delay <= 0) {
-            debugLog(`Fahrzeug ${vehicleId}: keine Verzögerung konfiguriert.`);
-            return;
-        }
-
-        if (pendingButtons.has(button)) {
-            event.preventDefault();
-            event.stopImmediatePropagation();
-            return;
-        }
-
-        event.preventDefault();
-        event.stopImmediatePropagation();
-        pendingButtons.add(button);
-        debugLog(`Fahrzeug ${vehicleId}: Alarmierung wird um ${delay}s verzögert.`);
-
-        const timeoutId = setTimeout(() => {
-            pendingButtons.delete(button);
-            bypassButtons.add(button);
-            button.click();
-        }, delay * 1000);
-
-        showCountdownBadge(button, delay, () => {
-            clearTimeout(timeoutId);
-            pendingButtons.delete(button);
-            debugLog(`Fahrzeug ${vehicleId}: Verzögerte Alarmierung abgebrochen.`);
-        });
-    }, true); // Capture-Phase: läuft vor dem Klick-Handler des Spiels
 
     // ---------------------------------------------------------------------
     // Styles
@@ -569,29 +517,8 @@
             outline: none;
             border-color: #3b82f6;
         }
-        .avz-countdown-badge {
-            display: inline-flex;
-            align-items: center;
-            gap: 6px;
-            font-size: 12px;
-            color: #ffcf5c;
-            background-color: rgba(255, 193, 7, 0.12);
-            border: 1px solid rgba(255, 193, 7, 0.4);
-            border-radius: 4px;
-            padding: 2px 6px;
-            margin-left: 4px;
-        }
-        .avz-countdown-cancel {
-            border: none;
-            background: #dc3545;
-            color: #fff;
-            border-radius: 3px;
-            font-size: 11px;
-            padding: 1px 6px;
-            cursor: pointer;
-        }
-        .avz-countdown-cancel:hover {
-            background: #b02a37;
+        .form-group input:disabled {
+            opacity: 0.5;
         }
         .avz-toast {
             position: fixed;
@@ -617,12 +544,9 @@
         }
     `);
 
-    migrateLegacyDelays();
-
-    // Da Wachen/Fahrzeuge als AJAX-Overlay ohne URL-Wechsel angezeigt
-    // werden, gibt es kein "Seite geladen"-Ereignis dafür - stattdessen
-    // wird bei jeder DOM-Änderung (debounced) neu geprüft, ob gerade eine
-    // Wache oder ein Fahrzeug sichtbar ist.
+    // Da Wachen als AJAX-Overlay ohne URL-Wechsel angezeigt werden, gibt
+    // es kein "Seite geladen"-Ereignis dafür - stattdessen wird bei jeder
+    // DOM-Änderung (debounced) neu geprüft, ob gerade eine Wache sichtbar ist.
     const debouncedRefresh = debounce(refreshForCurrentView, 400);
     new MutationObserver(debouncedRefresh).observe(document.body, { childList: true, subtree: true });
     refreshForCurrentView();

--- a/-Leitstellenspiel-Ausr-cke-Verz-gerung-der-Fahrzeuge.user.js
+++ b/-Leitstellenspiel-Ausr-cke-Verz-gerung-der-Fahrzeuge.user.js
@@ -1,176 +1,405 @@
 // ==UserScript==
 // @name         Leitstellenspiel Ausrücke-Verzögerung für einzelne Wache
 // @namespace    https://www.leitstellenspiel.de/
-// @version      3.1
-// @description  Zeigt Fahrzeuge der aktuellen Wache und ermöglicht die Konfiguration der Ausrückverzögerungen für diese Fahrzeuge (Rechtes Menü mit Scrollfunktion).
+// @version      4.0.0
+// @description  Zeigt Fahrzeuge der aktuellen Wache, ermöglicht die Konfiguration einer Ausrückverzögerung pro Fahrzeug und verzögert das tatsächliche Alarmieren im Spiel um die eingestellte Zeit.
 // @author       Hudnur111 - IBoy - Coding Crew Tag 1
 // @match        https://www.leitstellenspiel.de/buildings/*
+// @match        https://www.leitstellenspiel.de/missions/*
 // @icon         https://cdn-icons-png.flaticon.com/512/3135/3135715.png
 // @license      GPL-3.0-or-later
 // @grant        GM_addStyle
 // @grant        GM_notification
 // @grant        GM_xmlhttpRequest
+// @connect      raw.githubusercontent.com
+// @run-at       document-idle
 // ==/UserScript==
 
 // Betatester: m7e
 
-(function() {
+(function () {
     'use strict';
 
-    // Skriptinformationen
+    if (window.__lssAusrueckverzoegerungLoaded) return;
+    window.__lssAusrueckverzoegerungLoaded = true;
+
+    // ---------------------------------------------------------------------
+    // Skriptinformationen / Update-Check
+    // ---------------------------------------------------------------------
     const SCRIPT_NAME = 'Leitstellenspiel Ausrücke-Verzögerung für einzelne Wache';
-    const CURRENT_VERSION = '3.1';
+    const CURRENT_VERSION = '4.0.0';
     const UPDATE_URL = 'https://github.com/Hudnur111/-Leitstellenspiel-Ausr-cke-Verz-gerung-der-Fahrzeuge.user.js/raw/main/-Leitstellenspiel-Ausr-cke-Verz-gerung-der-Fahrzeuge.user.js';
     const VERSION_URL = 'https://raw.githubusercontent.com/Hudnur111/-Leitstellenspiel-Ausr-cke-Verz-gerung-der-Fahrzeuge/main/version.txt';
+    const UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000; // alle 6 Stunden, nicht bei jedem Seitenaufruf
+    const LAST_CHECK_KEY = 'lss_avz_last_update_check';
 
-    // Überprüft, ob es eine neue Version gibt
     function checkForUpdate() {
+        if (typeof GM_xmlhttpRequest !== 'function') return;
+
+        const lastCheck = Number(localStorage.getItem(LAST_CHECK_KEY) || 0);
+        if (Date.now() - lastCheck < UPDATE_CHECK_INTERVAL_MS) return;
+        localStorage.setItem(LAST_CHECK_KEY, String(Date.now()));
+
         GM_xmlhttpRequest({
             method: 'GET',
             url: VERSION_URL,
-            onload: function(response) {
+            onload(response) {
                 if (response.status === 200) {
                     const latestVersion = response.responseText.trim();
-                    if (latestVersion !== CURRENT_VERSION) {
+                    if (latestVersion && latestVersion !== CURRENT_VERSION) {
                         notifyUserForUpdate(latestVersion);
                     }
                 } else {
-                    console.error('Fehler beim Abrufen der Versionsinformationen:', response.statusText);
+                    console.warn(`[${SCRIPT_NAME}] Versionsprüfung fehlgeschlagen: ${response.status} ${response.statusText}`);
                 }
             },
-            onerror: function() {
-                console.error('Fehler beim Abrufen der Versionsinformationen.');
+            onerror() {
+                console.warn(`[${SCRIPT_NAME}] Versionsprüfung: Server nicht erreichbar.`);
             }
         });
     }
 
-    // Benachrichtigt den Benutzer über ein verfügbares Update
     function notifyUserForUpdate(latestVersion) {
+        if (typeof GM_notification !== 'function') return;
         GM_notification({
-            text: `${SCRIPT_NAME} (Version ${latestVersion}) Jetzt aktualisieren!`,
+            text: `${SCRIPT_NAME} (Version ${latestVersion}) ist verfügbar. Jetzt aktualisieren!`,
             title: 'Neue Version verfügbar',
-            onclick: function() {
+            onclick() {
                 window.open(UPDATE_URL, '_blank');
             }
         });
     }
 
-    // Funktion, um Fahrzeuge der aktuellen Wache zu laden
-    async function loadFahrzeuge() {
-        const wacheId = window.location.pathname.split('/')[2];
+    // ---------------------------------------------------------------------
+    // Verzögerungs-Speicher (localStorage, da das Spiel selbst keine
+    // Ausrückverzögerung kennt - diese wird ausschließlich clientseitig
+    // durch dieses Skript simuliert)
+    // ---------------------------------------------------------------------
+    const DELAY_KEY_PREFIX = 'lss_avz_delay_v1_';
+    const LEGACY_KEY_PREFIX = 'verzögerung-';
+    const MAX_DELAY_SECONDS = 900; // Sicherheitsobergrenze: 15 Minuten
 
-        try {
-            const response = await fetch(`/api/buildings/${wacheId}/vehicles`);
-            if (!response.ok) throw new Error(`Fehler beim Abrufen der Fahrzeuge: ${response.statusText}`);
-
-            const fahrzeuge = await response.json();
-            if (!Array.isArray(fahrzeuge) || fahrzeuge.length === 0) {
-                console.error('Keine Fahrzeuge für diese Wache gefunden oder API-Antwort ungültig.');
-                return;
+    // Alte, unpräfixte Keys (Version <= 3.1) einmalig übernehmen, damit
+    // bestehende Einstellungen der Nutzer nicht verloren gehen.
+    function migrateLegacyDelays() {
+        for (let i = localStorage.length - 1; i >= 0; i--) {
+            const key = localStorage.key(i);
+            if (!key || !key.startsWith(LEGACY_KEY_PREFIX)) continue;
+            const vehicleId = key.slice(LEGACY_KEY_PREFIX.length);
+            const newKey = DELAY_KEY_PREFIX + vehicleId;
+            if (localStorage.getItem(newKey) === null) {
+                localStorage.setItem(newKey, localStorage.getItem(key));
             }
-
-            fahrzeuge.sort((a, b) => a.vehicle_type_caption.localeCompare(b.vehicle_type_caption));
-            createSidebar(fahrzeuge);
-        } catch (error) {
-            console.error('Fehler beim Laden der Fahrzeuge:', error);
+            localStorage.removeItem(key);
         }
     }
 
-    // Funktion zur Erstellung des Buttons und der Sidebar
+    function getDelaySeconds(vehicleId) {
+        const raw = localStorage.getItem(DELAY_KEY_PREFIX + vehicleId);
+        const value = Number.parseInt(raw, 10);
+        if (!Number.isFinite(value) || value < 0) return 0;
+        return Math.min(value, MAX_DELAY_SECONDS);
+    }
+
+    function setDelaySeconds(vehicleId, delay) {
+        const value = Number.parseInt(delay, 10);
+        const clamped = Number.isFinite(value) && value > 0 ? Math.min(value, MAX_DELAY_SECONDS) : 0;
+        localStorage.setItem(DELAY_KEY_PREFIX + vehicleId, String(clamped));
+        return clamped;
+    }
+
+    // ---------------------------------------------------------------------
+    // Sidebar zur Konfiguration der Verzögerungen (nur auf /buildings/*)
+    // ---------------------------------------------------------------------
+    async function loadFahrzeuge() {
+        const match = window.location.pathname.match(/^\/buildings\/(\d+)/);
+        if (!match) return;
+        const wacheId = Number(match[1]);
+
+        try {
+            const response = await fetch('/api/vehicles', { credentials: 'same-origin' });
+            if (!response.ok) throw new Error(`Fehler beim Abrufen der Fahrzeuge: ${response.status} ${response.statusText}`);
+
+            const alleFahrzeuge = await response.json();
+            if (!Array.isArray(alleFahrzeuge)) {
+                throw new Error('Unerwartetes Antwortformat der Fahrzeug-API.');
+            }
+
+            const fahrzeuge = alleFahrzeuge
+                .filter(fz => Number(fz.building_id) === wacheId)
+                .sort((a, b) => (a.caption || '').localeCompare(b.caption || ''));
+
+            if (fahrzeuge.length === 0) {
+                console.info(`[${SCRIPT_NAME}] Keine Fahrzeuge für Wache ${wacheId} gefunden.`);
+                return;
+            }
+
+            createSidebar(fahrzeuge);
+        } catch (error) {
+            console.error(`[${SCRIPT_NAME}] Fehler beim Laden der Fahrzeuge:`, error);
+        }
+    }
+
     function createSidebar(fahrzeuge) {
         const toggleButton = document.createElement('button');
-        toggleButton.innerHTML = '🚒 Fahrzeugeinstellungen';
-        toggleButton.style.position = 'fixed';
-        toggleButton.style.bottom = '20px';
-        toggleButton.style.right = '20px';
-        toggleButton.style.zIndex = '1000';
-        toggleButton.style.backgroundColor = '#007bff';
-        toggleButton.style.color = 'white';
-        toggleButton.style.border = 'none';
-        toggleButton.style.padding = '10px 20px';
-        toggleButton.style.borderRadius = '5px';
-        toggleButton.style.boxShadow = '0 2px 10px rgba(0,0,0,0.1)';
-        toggleButton.style.cursor = 'pointer';
+        toggleButton.id = 'avzToggleButton';
+        toggleButton.type = 'button';
+        toggleButton.textContent = '🚒 Fahrzeugeinstellungen';
         document.body.appendChild(toggleButton);
 
         const sidebar = document.createElement('div');
         sidebar.id = 'vehicleSidebar';
-        sidebar.style.position = 'fixed';
-        sidebar.style.top = '100px';
-        sidebar.style.right = '10px';
-        sidebar.style.width = '350px';
-        sidebar.style.height = '400px';
-        sidebar.style.overflowY = 'auto';
-        sidebar.style.backgroundColor = '#f8f9fa';
-        sidebar.style.border = '1px solid #ccc';
-        sidebar.style.padding = '20px';
-        sidebar.style.boxShadow = '0 2px 10px rgba(0,0,0,0.1)';
-        sidebar.style.zIndex = '1000';
-        sidebar.style.display = 'none'; // Start hidden
+        sidebar.style.display = 'none';
         sidebar.innerHTML = `
-            <h4>Fahrzeug-Ausfahr-Verzögerung</h4>
-            <div id="fahrzeugVerzögerungList"></div>
-            <button class="btn btn-primary" id="saveDelays" style="margin-top: 10px;">Speichern</button>
-            <span id="saveFeedback" class="text-success" style="display:none; margin-top: 10px;">Verzögerungen erfolgreich gespeichert!</span>
+            <div class="avz-header">
+                <h4>Fahrzeug-Ausrück-Verzögerung</h4>
+                <button type="button" id="avzCloseButton" aria-label="Schließen">&times;</button>
+            </div>
+            <p class="avz-hint">Verzögerung in Sekunden je Fahrzeug. Bei 0 wird sofort alarmiert.</p>
+            <div id="fahrzeugVerzoegerungList"></div>
+            <button class="btn btn-primary" id="saveDelays">Speichern</button>
+            <span id="saveFeedback" class="avz-feedback" style="display:none;">Verzögerungen erfolgreich gespeichert!</span>
         `;
         document.body.appendChild(sidebar);
 
-        const fahrzeugList = document.getElementById('fahrzeugVerzögerungList');
+        const fahrzeugList = sidebar.querySelector('#fahrzeugVerzoegerungList');
 
         fahrzeuge.forEach(fz => {
+            const label = fz.vehicle_type_caption || fz.caption || `Fahrzeug #${fz.id}`;
             const fzItem = document.createElement('div');
             fzItem.className = 'form-group';
-            fzItem.innerHTML = `
-                <label>${fz.vehicle_type_caption || fz.caption || 'Unbekanntes Fahrzeug'}</label>
-                <input type="number" class="form-control delayInput" id="fz-${fz.id}" placeholder="Verzögerung in Sekunden" value="${getVerzögerung(fz.id)}">
-            `;
-            fahrzeugList.appendChild(fzItem);
 
-            // Debugging: Ausgabe der Verzögerungen
-            console.log(`Fahrzeug ID ${fz.id}: ${getVerzögerung(fz.id)}`);
+            const labelEl = document.createElement('label');
+            labelEl.textContent = label;
+            labelEl.setAttribute('for', `avz-fz-${fz.id}`);
+
+            const input = document.createElement('input');
+            input.type = 'number';
+            input.className = 'form-control delayInput';
+            input.id = `avz-fz-${fz.id}`;
+            input.min = '0';
+            input.max = String(MAX_DELAY_SECONDS);
+            input.placeholder = 'Verzögerung in Sekunden';
+            input.value = String(getDelaySeconds(fz.id));
+            input.dataset.vehicleId = String(fz.id);
+
+            fzItem.appendChild(labelEl);
+            fzItem.appendChild(input);
+            fahrzeugList.appendChild(fzItem);
         });
 
-        document.getElementById('saveDelays').addEventListener('click', () => {
-            saveDelays(fahrzeuge);
+        sidebar.querySelector('#saveDelays').addEventListener('click', () => saveDelays(fahrzeuge));
+        sidebar.querySelector('#avzCloseButton').addEventListener('click', () => {
+            sidebar.style.display = 'none';
         });
 
         toggleButton.addEventListener('click', () => {
             sidebar.style.display = (sidebar.style.display === 'none') ? 'block' : 'none';
         });
 
-        // Ermögliche das Speichern durch Drücken der Enter-Taste
-        document.querySelectorAll('.delayInput').forEach(input => {
-            input.addEventListener('keypress', (e) => {
-                if (e.key === 'Enter') {
-                    saveDelays(fahrzeuge);
-                }
-            });
+        fahrzeugList.addEventListener('keypress', (e) => {
+            if (e.key === 'Enter' && e.target.classList.contains('delayInput')) {
+                e.preventDefault();
+                saveDelays(fahrzeuge);
+            }
         });
     }
 
     function saveDelays(fahrzeuge) {
         fahrzeuge.forEach(fz => {
-            const delay = document.getElementById(`fz-${fz.id}`).value;
-            console.log(`Speichern: Fahrzeug ID ${fz.id}, Verzögerung ${delay}`); // Debugging
-            setVerzögerung(fz.id, delay);
+            const input = document.getElementById(`avz-fz-${fz.id}`);
+            if (!input) return;
+            const clamped = setDelaySeconds(fz.id, input.value);
+            input.value = String(clamped);
         });
-        document.getElementById('saveFeedback').style.display = 'inline';
-        setTimeout(() => {
-            document.getElementById('saveFeedback').style.display = 'none';
-        }, 2000);
+
+        const feedback = document.getElementById('saveFeedback');
+        feedback.style.display = 'inline';
+        setTimeout(() => { feedback.style.display = 'none'; }, 2000);
     }
 
-    function getVerzögerung(fahrzeugId) {
-        const delay = localStorage.getItem(`verzögerung-${fahrzeugId}`) || 0;
-        console.log(`Verzögerung für Fahrzeug ID ${fahrzeugId}: ${delay}`); // Debugging
-        return delay;
+    // ---------------------------------------------------------------------
+    // Ausrück-Interceptor: verzögert das tatsächliche Alarmieren
+    //
+    // Leitstellenspiel kennt serverseitig keine Ausrückverzögerung - das
+    // Spiel löst die Alarmierung eines Fahrzeugs über einen AJAX-Link
+    // (Rails-UJS, `data-remote="true"`) auf `/vehicles/<id>/...` aus, z.B.
+    // beim Rückalarmieren `/vehicles/<id>/backalarm?return=mission`. Der
+    // Interceptor fängt den Klick auf einen solchen Alarmieren-Link ab,
+    // zeigt einen Countdown an und löst den echten Klick erst danach aus,
+    // damit Rails-UJS die Anfrage wie gewohnt verarbeitet.
+    //
+    // Hinweis: Ohne Zugriff auf einen eingeloggten Testaccount konnte der
+    // exakte href-Aufbau des "Alarmieren"-Links nicht live verifiziert
+    // werden. Greift die Erkennung nicht, passiert nichts Schädliches -
+    // das Fahrzeug rückt einfach ohne Verzögerung aus wie bisher. Über
+    // `window.__lssAvzDebug = true` in der Konsole lässt sich mitloggen,
+    // welche Links erkannt/ignoriert werden, um den Selektor bei Bedarf
+    // anzupassen.
+    // ---------------------------------------------------------------------
+    const pendingLinks = new WeakSet();
+    const bypassLinks = new WeakSet();
+
+    function extractVehicleId(href) {
+        const match = href.match(/\/vehicles\/(\d+)/);
+        return match ? match[1] : null;
     }
 
-    function setVerzögerung(fahrzeugId, delay) {
-        localStorage.setItem(`verzögerung-${fahrzeugId}`, delay);
+    function isDispatchLink(link) {
+        if (!(link instanceof HTMLAnchorElement)) return false;
+        const href = link.getAttribute('href') || '';
+        if (!/\/vehicles\/\d+/.test(href)) return false;
+        if (/backalarm|zurueck|recall/i.test(href)) return false; // Rückalarmierung ausschließen
+        return /alarm/i.test(href);
     }
 
+    function debugLog(...args) {
+        if (window.__lssAvzDebug) console.log(`[${SCRIPT_NAME}]`, ...args);
+    }
+
+    function showCountdownBadge(link, seconds, onCancel) {
+        const badge = document.createElement('span');
+        badge.className = 'avz-countdown-badge';
+        let remaining = seconds;
+        badge.textContent = ` (Ausrücken in ${remaining}s) `;
+
+        const cancelBtn = document.createElement('button');
+        cancelBtn.type = 'button';
+        cancelBtn.className = 'avz-countdown-cancel';
+        cancelBtn.textContent = 'Abbrechen';
+        badge.appendChild(cancelBtn);
+
+        link.insertAdjacentElement('afterend', badge);
+
+        const interval = setInterval(() => {
+            remaining -= 1;
+            badge.firstChild.textContent = ` (Ausrücken in ${Math.max(remaining, 0)}s) `;
+        }, 1000);
+
+        cancelBtn.addEventListener('click', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            clearInterval(interval);
+            badge.remove();
+            onCancel();
+        });
+
+        return {
+            remove() {
+                clearInterval(interval);
+                badge.remove();
+            }
+        };
+    }
+
+    document.addEventListener('click', (event) => {
+        const link = event.target.closest('a');
+        if (!link) return;
+
+        if (bypassLinks.has(link)) {
+            bypassLinks.delete(link);
+            debugLog('Verzögerter Klick wird durchgelassen:', link.href);
+            return; // Diesen Klick unverändert durchlassen (echte Alarmierung)
+        }
+
+        if (!isDispatchLink(link)) {
+            debugLog('Kein Alarmieren-Link, ignoriert:', link.getAttribute('href'));
+            return;
+        }
+
+        const vehicleId = extractVehicleId(link.getAttribute('href') || '');
+        if (!vehicleId) return;
+
+        const delay = getDelaySeconds(vehicleId);
+        if (delay <= 0) {
+            debugLog(`Fahrzeug ${vehicleId}: keine Verzögerung konfiguriert.`);
+            return;
+        }
+
+        if (pendingLinks.has(link)) {
+            // Bereits ein Countdown für diesen Link aktiv - weiteren Klick ignorieren
+            event.preventDefault();
+            event.stopImmediatePropagation();
+            return;
+        }
+
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        pendingLinks.add(link);
+        debugLog(`Fahrzeug ${vehicleId}: Alarmierung wird um ${delay}s verzögert.`);
+
+        const timeoutId = setTimeout(() => {
+            pendingLinks.delete(link);
+            bypassLinks.add(link);
+            link.click();
+        }, delay * 1000);
+
+        showCountdownBadge(link, delay, () => {
+            clearTimeout(timeoutId);
+            pendingLinks.delete(link);
+            debugLog(`Fahrzeug ${vehicleId}: Verzögerte Alarmierung abgebrochen.`);
+        });
+    }, true); // Capture-Phase: läuft vor dem Rails-UJS-Handler des Spiels
+
+    // ---------------------------------------------------------------------
+    // Styles
+    // ---------------------------------------------------------------------
     GM_addStyle(`
+        #avzToggleButton {
+            position: fixed;
+            bottom: 20px;
+            right: 20px;
+            z-index: 1000;
+            background-color: #007bff;
+            color: #fff;
+            border: none;
+            padding: 10px 20px;
+            border-radius: 5px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.2);
+            cursor: pointer;
+        }
+        #avzToggleButton:hover {
+            background-color: #0056b3;
+        }
+        #vehicleSidebar {
+            position: fixed;
+            top: 100px;
+            right: 10px;
+            width: 350px;
+            max-height: 70vh;
+            overflow-y: auto;
+            background-color: #f8f9fa;
+            color: #212529;
+            border: 1px solid #ccc;
+            border-radius: 6px;
+            padding: 15px 20px 20px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.2);
+            z-index: 1000;
+        }
+        #vehicleSidebar .avz-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+        }
+        #vehicleSidebar .avz-header h4 {
+            margin: 0;
+        }
+        #avzCloseButton {
+            background: none;
+            border: none;
+            font-size: 22px;
+            line-height: 1;
+            cursor: pointer;
+            color: #666;
+        }
+        #avzCloseButton:hover {
+            color: #000;
+        }
+        #vehicleSidebar .avz-hint {
+            font-size: 12px;
+            color: #666;
+            margin: 8px 0 12px;
+        }
         #vehicleSidebar input {
             margin-bottom: 10px;
         }
@@ -179,10 +408,18 @@
             border-color: #007bff;
             padding: 8px 16px;
             color: white;
+            border-radius: 4px;
+            border: 1px solid #007bff;
+            cursor: pointer;
         }
         .btn-primary:hover {
             background-color: #0056b3;
             border-color: #004085;
+        }
+        .avz-feedback {
+            display: inline-block;
+            margin-left: 10px;
+            color: #28a745;
         }
         .form-group {
             margin-bottom: 15px;
@@ -196,9 +433,35 @@
             padding: 8px;
             border: 1px solid #ccc;
             border-radius: 4px;
+            box-sizing: border-box;
+        }
+        .avz-countdown-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            font-size: 12px;
+            color: #856404;
+            background-color: #fff3cd;
+            border: 1px solid #ffeeba;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin-left: 4px;
+        }
+        .avz-countdown-cancel {
+            border: none;
+            background: #dc3545;
+            color: #fff;
+            border-radius: 3px;
+            font-size: 11px;
+            padding: 1px 6px;
+            cursor: pointer;
+        }
+        .avz-countdown-cancel:hover {
+            background: #b02a37;
         }
     `);
 
-    checkForUpdate(); // Check for updates when script is loaded
-    loadFahrzeuge(); // Initialize the script when the page is loaded
+    migrateLegacyDelays();
+    checkForUpdate();
+    loadFahrzeuge();
 })();

--- a/-Leitstellenspiel-Ausr-cke-Verz-gerung-der-Fahrzeuge.user.js
+++ b/-Leitstellenspiel-Ausr-cke-Verz-gerung-der-Fahrzeuge.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Leitstellenspiel Ausrücke-Verzögerung für einzelne Wache
 // @namespace    https://www.leitstellenspiel.de/
-// @version      6.0.0
+// @version      6.1.0
 // @description  Zeigt alle Fahrzeuge der aktuellen Wache in einer Sidebar und ermöglicht das komfortable Bearbeiten der nativen "Ausrücke-Verzögerung" für alle Fahrzeuge an einer Stelle.
 // @author       Hudnur111 - IBoy - Coding Crew Tag 1
 // @match        https://www.leitstellenspiel.de/*
@@ -33,7 +33,7 @@
     // zudem auf eine nicht existierende version.txt und lief nie).
     // ---------------------------------------------------------------------
     const SCRIPT_NAME = 'Leitstellenspiel Ausrücke-Verzögerung für einzelne Wache';
-    const CURRENT_VERSION = '6.0.0';
+    const CURRENT_VERSION = '6.1.0';
 
     // ---------------------------------------------------------------------
     // Sichtbare Status-/Fehlermeldungen. Fehler beim Laden der Fahrzeuge
@@ -411,15 +411,17 @@
     // ---------------------------------------------------------------------
     // Styles
     // ---------------------------------------------------------------------
-    // Farben/Look an die dunkle Leitstellenspiel-Oberfläche angelehnt
-    // (dunkle Panels, helle Schrift, blaue Akzentfarbe für Buttons).
+    // Farben an die tatsächliche Leitstellenspiel-Oberfläche angelehnt:
+    // neutrales dunkles Grau statt Navy-Blau für Panels, und Grün (wie der
+    // "Alarmieren"-Button und aktive Kategorie-Buttons im Spiel) als
+    // Akzentfarbe statt Blau.
     GM_addStyle(`
         #avzToggleButton {
             position: fixed;
             bottom: 20px;
             right: 20px;
             z-index: 10000;
-            background-color: #3b82f6;
+            background-color: #3ba757;
             color: #fff;
             border: none;
             padding: 10px 20px;
@@ -430,7 +432,7 @@
             cursor: pointer;
         }
         #avzToggleButton:hover {
-            background-color: #2563eb;
+            background-color: #2f8a46;
         }
         #vehicleSidebar {
             position: fixed;
@@ -439,7 +441,7 @@
             width: 360px;
             max-height: 70vh;
             overflow-y: auto;
-            background-color: #1b1f27;
+            background-color: #2e2e2e;
             color: #e8e8e8;
             border: 1px solid rgba(255,255,255,0.12);
             border-radius: 8px;
@@ -477,18 +479,18 @@
             margin: 10px 0 14px;
         }
         .btn-primary {
-            background-color: #3b82f6;
-            border-color: #3b82f6;
+            background-color: #3ba757;
+            border-color: #3ba757;
             padding: 8px 16px;
             color: #fff;
             border-radius: 5px;
-            border: 1px solid #3b82f6;
+            border: 1px solid #3ba757;
             cursor: pointer;
             font-weight: bold;
         }
         .btn-primary:hover {
-            background-color: #2563eb;
-            border-color: #2563eb;
+            background-color: #2f8a46;
+            border-color: #2f8a46;
         }
         .avz-feedback {
             display: inline-block;
@@ -507,15 +509,15 @@
         .form-group input {
             width: 100%;
             padding: 8px;
-            background-color: #11141a;
+            background-color: #1e1e1e;
             color: #fff;
-            border: 1px solid #3a3f4b;
+            border: 1px solid #4a4a4a;
             border-radius: 5px;
             box-sizing: border-box;
         }
         .form-group input:focus {
             outline: none;
-            border-color: #3b82f6;
+            border-color: #3ba757;
         }
         .form-group input:disabled {
             opacity: 0.5;
@@ -533,11 +535,11 @@
             color: #fff;
         }
         .avz-toast-info {
-            background-color: #3b82f6;
+            background-color: #3ba757;
         }
         .avz-toast-warning {
             background-color: #e0a800;
-            color: #1b1f27;
+            color: #1e1e1e;
         }
         .avz-toast-error {
             background-color: #dc3545;

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🚒 Leitstellenspiel Ausrücke-Verzögerung für einzelne Wache (v4.0.0)
+# 🚒 Leitstellenspiel Ausrücke-Verzögerung für einzelne Wache (v5.0.0)
 
 **Autor:** Hudnur111 · IBoy · Coding Crew Tag 1  
 **Status:** In Entwicklung  
@@ -54,20 +54,29 @@ Es wird empfohlen, regelmäßig nach Updates zu schauen, um von den neuesten Ver
 
 ## ℹ️ Sonstige Informationen
 
-### 🧪 Aktueller Entwicklungsstand (v4.0.0)
+### 🧪 Aktueller Entwicklungsstand (v5.0.0)
 
-Leitstellenspiel kennt **serverseitig keine Ausrückverzögerung** – diese Funktion existiert im Spiel selbst nicht (siehe Forendiskussionen dazu). Bis Version 3.1 hat das Skript die eingestellte Verzögerung nur in `localStorage` gespeichert, ohne dass sie irgendeinen Effekt im Spiel hatte – die Kernfunktion war faktisch ein Platzhalter.
+Leitstellenspiel kennt **serverseitig keine Ausrückverzögerung** – diese Funktion existiert im Spiel selbst nicht. Bis Version 3.1 hat das Skript die eingestellte Verzögerung nur in `localStorage` gespeichert, ohne dass sie irgendeinen Effekt im Spiel hatte.
 
-Ab v4.0.0 fängt das Skript den echten Alarmieren-Klick im Spiel ab (Rails-UJS-Link auf `/vehicles/<id>/...`) und verzögert ihn aktiv um die konfigurierte Zeit, inklusive sichtbarem Countdown und Abbrechen-Option. Außerdem wurde behoben:
+**Wichtige Erkenntnis in v5.0.0:** Leitstellenspiel öffnet Wachen und Fahrzeuge als AJAX-Overlay, **ohne die Browser-URL zu wechseln**. Das Skript hat sich bis v4.1.0 auf `window.location.pathname` (`/buildings/123`) verlassen, das in der echten Spieloberfläche nie zutrifft – deshalb hat das Skript nie reagiert.
 
-- Falscher API-Endpunkt (`/api/buildings/{id}/vehicles` existiert nicht) → jetzt `/api/vehicles`, gefiltert nach Wache
+Seit v5.0.0:
+
+- Die aktuell angezeigte Wache/das Fahrzeug wird über den **sichtbaren Namen** (Überschrift im Overlay) erkannt und mit `/api/buildings` bzw. `/api/vehicles` abgeglichen – unabhängig von der URL
+- Ein `MutationObserver` beobachtet das Overlay laufend, da es ohne klassischen Seitenwechsel per AJAX nachlädt
+- Der „Alarmieren“-Button wird über seinen sichtbaren Text erkannt (nicht mehr über einen geratenen Link-Aufbau)
+- `@match` gilt jetzt für die komplette Domain (`leitstellenspiel.de/*`), damit das Skript unabhängig vom Overlay-Zustand aktiv ist
+
+Außerdem wurde behoben:
+
+- Falscher API-Endpunkt (`/api/buildings/{id}/vehicles` existiert nicht) → jetzt `/api/vehicles` und `/api/buildings`
 - Versionsprüfung lief bei **jedem** Seitenaufruf gegen GitHub → jetzt auf alle 6 Stunden gedrosselt
-- Fehlende Fehlerrückmeldung im UI bei fehlgeschlagenem Laden der Fahrzeuge
+- Fehlende Fehlerrückmeldung im UI bei fehlgeschlagenem Laden der Fahrzeuge → sichtbare Toast-Meldungen
 - Bestehende Verzögerungen aus v3.1 werden beim ersten Start automatisch migriert
 
-⚠️ **Bekannte Einschränkung:** Der genaue Aufbau des „Alarmieren"-Links konnte ohne Zugriff auf einen eingeloggten Testaccount nicht live verifiziert werden. Greift die Erkennung nicht, rückt das Fahrzeug wie gewohnt ohne Verzögerung aus (kein Absturz, kein Blockieren). Zum Debuggen `window.__lssAvzDebug = true` in der Browser-Konsole setzen – dort wird jeder erkannte/ignorierte Link geloggt.
+⚠️ **Bekannte Einschränkung:** Die Erkennung basiert auf sichtbarem Text (Wachen-/Fahrzeugname, Button-Beschriftung „Alarmieren"). Weicht das Overlay strukturell stark ab, kann die Zuordnung fehlschlagen – dann greift keine Verzögerung, aber das Fahrzeug rückt wie gewohnt aus (kein Absturz). Zum Debuggen `window.__lssAvzDebug = true` in der Browser-Konsole setzen.
 
-🛠️ Rückmeldungen zum Live-Verhalten (insbesondere ob der Countdown beim Alarmieren erscheint) sind willkommen.
+🛠️ Rückmeldungen zum Live-Verhalten sind willkommen.
 
 ---
 📬 **Feedback & Vorschläge**?  

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🚒 Leitstellenspiel Ausrücke-Verzögerung für einzelne Wache (v5.0.0)
+# 🚒 Leitstellenspiel Ausrücke-Verzögerung für einzelne Wache (v5.1.0)
 
 **Autor:** Hudnur111 · IBoy · Coding Crew Tag 1  
 **Status:** In Entwicklung  
@@ -30,8 +30,8 @@ Es ergänzt die Spieloberfläche um eine moderne, benutzerfreundliche **Sidebar*
 - 🧭 **Benutzerfreundliche Steuerung**  
   Ein Button in der unteren rechten Ecke öffnet oder schließt die Sidebar.
 
-- 🔄 **Versionsprüfung**  
-  Das Skript prüft automatisch (höchstens alle 6 Stunden) auf **verfügbare Updates** und informiert den Nutzer entsprechend.
+- 🔄 **Automatische Updates**  
+  Tampermonkey prüft selbstständig (über `@updateURL`/`@downloadURL`), ob im GitHub-Repo eine neue Version vorliegt, und installiert sie automatisch – kein manuelles Nachschauen nötig.
 
 ---
 
@@ -54,7 +54,15 @@ Es wird empfohlen, regelmäßig nach Updates zu schauen, um von den neuesten Ver
 
 ## ℹ️ Sonstige Informationen
 
-### 🧪 Aktueller Entwicklungsstand (v5.0.0)
+### 🧪 Aktueller Entwicklungsstand (v5.1.0)
+
+**Automatische Updates (v5.1.0):** Das Skript enthält jetzt `@updateURL`/`@downloadURL` im Header. Tampermonkey prüft damit selbstständig (Standardeinstellung: periodisch im Hintergrund), ob sich `@version` in der `main`-Branch-Datei erhöht hat, und installiert neue Versionen automatisch. Voraussetzungen dafür:
+
+1. Änderungen müssen in den `main`-Branch des Repos gemergt sein (nicht nur in einen Feature-Branch) – nur davon liest Tampermonkey.
+2. In Tampermonkey unter *Einstellungen → Update* muss die automatische Update-Prüfung aktiviert sein (Standard: an).
+3. Nach dem Einspielen dieser Version einmalig das Skript neu installieren bzw. in Tampermonkey unter *Dashboard → Skript → Updates prüfen* einmal manuell aktualisieren, damit die neuen `@updateURL`-Angaben übernommen werden. Ab dann läuft es automatisch.
+
+Der bisherige eigene Update-Check per `GM_xmlhttpRequest` wurde entfernt – er zeigte auf eine nicht existierende `version.txt` und hat nie funktioniert. `@updateURL`/`@downloadURL` sind der Standard-Mechanismus von Tampermonkey/Greasemonkey und robuster.
 
 Leitstellenspiel kennt **serverseitig keine Ausrückverzögerung** – diese Funktion existiert im Spiel selbst nicht. Bis Version 3.1 hat das Skript die eingestellte Verzögerung nur in `localStorage` gespeichert, ohne dass sie irgendeinen Effekt im Spiel hatte.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🚒 Leitstellenspiel Ausrücke-Verzögerung für einzelne Wache (v3.1)
+# 🚒 Leitstellenspiel Ausrücke-Verzögerung für einzelne Wache (v4.0.0)
 
 **Autor:** Hudnur111 · IBoy · Coding Crew Tag 1  
 **Status:** In Entwicklung  
@@ -9,9 +9,7 @@
 ## 📌 Beschreibung
 
 Dieses **Benutzerskript** für das Spiel **Leitstellenspiel** bietet eine erweiterte Möglichkeit zur **individuellen Konfiguration von Ausrückverzögerungen** für Fahrzeuge **einer einzelnen Wache**.  
-Es ergänzt die Spieloberfläche um eine moderne, benutzerfreundliche **Sidebar**, mit der alle Verzögerungen übersichtlich und intuitiv angepasst werden können.
-
-Das Skript befindet sich aktuell in der **aktiven Entwicklungsphase** und wird kontinuierlich erweitert und optimiert.
+Es ergänzt die Spieloberfläche um eine moderne, benutzerfreundliche **Sidebar**, mit der alle Verzögerungen übersichtlich und intuitiv angepasst werden können, und verzögert das tatsächliche Alarmieren im Spiel um die eingestellte Zeit.
 
 ---
 
@@ -20,6 +18,9 @@ Das Skript befindet sich aktuell in der **aktiven Entwicklungsphase** und wird k
 - 🔧 **Individuelle Fahrzeugverzögerungen**  
   Passen Sie die Ausrückverzögerungen **pro Fahrzeug** direkt über die Sidebar an – einfach, flexibel und in Echtzeit.
 
+- ⏱️ **Echte Verzögerung beim Alarmieren**  
+  Beim Klick auf „Alarmieren“ im Spiel erscheint ein Countdown; das Fahrzeug rückt erst danach tatsächlich aus. Der Countdown kann jederzeit abgebrochen werden.
+
 - 🎨 **Professionelles Design**  
   Die Sidebar ist modern gestaltet, bietet eine klare Struktur und eine Scrollfunktion für lange Fahrzeuglisten.
 
@@ -27,10 +28,10 @@ Das Skript befindet sich aktuell in der **aktiven Entwicklungsphase** und wird k
   Verzögerungen können entweder über die **„Speichern“-Schaltfläche** oder durch **Drücken der Enter-Taste** gesichert werden.
 
 - 🧭 **Benutzerfreundliche Steuerung**  
-  Ein Button in der unteren rechten Ecke öffnet oder schließt die Sidebar. Lange Fahrzeuglisten lassen sich schnell durchsuchen.
+  Ein Button in der unteren rechten Ecke öffnet oder schließt die Sidebar.
 
 - 🔄 **Versionsprüfung**  
-  Das Skript prüft automatisch auf **verfügbare Updates** und informiert den Nutzer entsprechend.
+  Das Skript prüft automatisch (höchstens alle 6 Stunden) auf **verfügbare Updates** und informiert den Nutzer entsprechend.
 
 ---
 
@@ -38,7 +39,7 @@ Das Skript befindet sich aktuell in der **aktiven Entwicklungsphase** und wird k
 
 Dieses Skript kann mithilfe eines **UserScript-Managers** wie **Tampermonkey** oder **Greasemonkey** in Ihrem Browser installiert werden:
 
-1. Erweiterung (z. B. Tampermonkey) installieren  
+1. Erweiterung (z. B. Tampermonkey) installieren  
 2. Skript einfügen und aktivieren  
 3. Sicherstellen, dass das Skript auf den Seiten von [Leitstellenspiel](https://www.leitstellenspiel.de) ausgeführt wird
 
@@ -51,27 +52,23 @@ Es wird empfohlen, regelmäßig nach Updates zu schauen, um von den neuesten Ver
 
 ---
 
-
 ## ℹ️ Sonstige Informationen
 
-### 🧪 Aktueller Entwicklungsstand: Fehlerbehebung
+### 🧪 Aktueller Entwicklungsstand (v4.0.0)
 
-Aktuell befindet sich das Skript in der **Fehlerbehebungsphase**, insbesondere hinsichtlich der **Integration mit der Spielumgebung** von Leitstellenspiel.
+Leitstellenspiel kennt **serverseitig keine Ausrückverzögerung** – diese Funktion existiert im Spiel selbst nicht (siehe Forendiskussionen dazu). Bis Version 3.1 hat das Skript die eingestellte Verzögerung nur in `localStorage` gespeichert, ohne dass sie irgendeinen Effekt im Spiel hatte – die Kernfunktion war faktisch ein Platzhalter.
 
-🔧 **Bekanntes Problem:**  
-Die **Kommunikation zwischen dem Skript und der Spiel-API** ist derzeit **nicht vollständig funktionsfähig**.  
-Es besteht ein Fehler in der **Verknüpfungslogik**, wodurch das Skript **nicht korrekt auf DOM-Elemente oder Spieldaten** zugreifen kann.
+Ab v4.0.0 fängt das Skript den echten Alarmieren-Klick im Spiel ab (Rails-UJS-Link auf `/vehicles/<id>/...`) und verzögert ihn aktiv um die konfigurierte Zeit, inklusive sichtbarem Countdown und Abbrechen-Option. Außerdem wurde behoben:
 
-➡️ **Technischer Hintergrund:**  
-Die fehlerhafte Implementierung betrifft die **Event Listener-Anbindung sowie die DOM-Abfrage für dynamisch geladene Inhalte**. Zudem gibt es Probleme mit der **Synchronisation der JavaScript-Ausführung mit den Ladevorgängen des Spiels**, was zu unvollständigen oder fehlerhaften Initialisierungen führt.
+- Falscher API-Endpunkt (`/api/buildings/{id}/vehicles` existiert nicht) → jetzt `/api/vehicles`, gefiltert nach Wache
+- Versionsprüfung lief bei **jedem** Seitenaufruf gegen GitHub → jetzt auf alle 6 Stunden gedrosselt
+- Fehlende Fehlerrückmeldung im UI bei fehlgeschlagenem Laden der Fahrzeuge
+- Bestehende Verzögerungen aus v3.1 werden beim ersten Start automatisch migriert
 
-Wir arbeiten aktiv an einer **Optimierung der Verbindungsschicht** zwischen Skript und Spiel (z. B. durch gezieltes DOM-Monitoring, asynchrone Initialisierung und API-kompatible Schnittstellenlogik).
+⚠️ **Bekannte Einschränkung:** Der genaue Aufbau des „Alarmieren"-Links konnte ohne Zugriff auf einen eingeloggten Testaccount nicht live verifiziert werden. Greift die Erkennung nicht, rückt das Fahrzeug wie gewohnt ohne Verzögerung aus (kein Absturz, kein Blockieren). Zum Debuggen `window.__lssAvzDebug = true` in der Browser-Konsole setzen – dort wird jeder erkannte/ignorierte Link geloggt.
 
-🛠️ Updates folgen zeitnah.
+🛠️ Rückmeldungen zum Live-Verhalten (insbesondere ob der Countdown beim Alarmieren erscheint) sind willkommen.
 
 ---
 📬 **Feedback & Vorschläge**?  
 Eröffne gerne ein Issue oder schick einen Pull Request – wir freuen uns über Unterstützung und Ideen!
-
-
-

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🚒 Leitstellenspiel Ausrücke-Verzögerung für einzelne Wache (v5.1.0)
+# 🚒 Leitstellenspiel Ausrücke-Verzögerung für einzelne Wache (v6.0.0)
 
 **Autor:** Hudnur111 · IBoy · Coding Crew Tag 1  
 **Status:** In Entwicklung  
@@ -8,24 +8,20 @@
 
 ## 📌 Beschreibung
 
-Dieses **Benutzerskript** für das Spiel **Leitstellenspiel** bietet eine erweiterte Möglichkeit zur **individuellen Konfiguration von Ausrückverzögerungen** für Fahrzeuge **einer einzelnen Wache**.  
-Es ergänzt die Spieloberfläche um eine moderne, benutzerfreundliche **Sidebar**, mit der alle Verzögerungen übersichtlich und intuitiv angepasst werden können, und verzögert das tatsächliche Alarmieren im Spiel um die eingestellte Zeit.
+Dieses **Benutzerskript** für das Spiel **Leitstellenspiel** zeigt alle Fahrzeuge der aktuellen Wache in einer übersichtlichen Sidebar und macht die native **„Ausrücke-Verzögerung"** jedes Fahrzeugs (Zeit in Sekunden, bis es nach der Alarmierung die Wache verlässt) an einer zentralen Stelle bearbeitbar, statt jedes Fahrzeug einzeln über „Fahrzeug bearbeiten“ öffnen zu müssen.
 
 ---
 
 ## ✨ Hauptfunktionen
 
-- 🔧 **Individuelle Fahrzeugverzögerungen**  
-  Passen Sie die Ausrückverzögerungen **pro Fahrzeug** direkt über die Sidebar an – einfach, flexibel und in Echtzeit.
+- 🔧 **Alle Fahrzeuge einer Wache an einer Stelle**  
+  Sidebar zeigt jedes Fahrzeug der aktuell geöffneten Wache mit seiner echten, aktuellen Ausrücke-Verzögerung.
 
-- ⏱️ **Echte Verzögerung beim Alarmieren**  
-  Beim Klick auf „Alarmieren“ im Spiel erscheint ein Countdown; das Fahrzeug rückt erst danach tatsächlich aus. Der Countdown kann jederzeit abgebrochen werden.
+- 💾 **Schreibt direkt in die native Spiel-Einstellung**  
+  Beim Speichern wird die echte „Fahrzeug bearbeiten“-Seite im Hintergrund abgerufen und mit dem neuen Wert erneut abgeschickt – alle anderen Felder (Funkrufname, Personenanzahl, Arbeitszeiten, …) bleiben unverändert.
 
-- 🎨 **Professionelles Design**  
-  Die Sidebar ist modern gestaltet, bietet eine klare Struktur und eine Scrollfunktion für lange Fahrzeuglisten.
-
-- 💾 **Speicherfunktion**  
-  Verzögerungen können entweder über die **„Speichern“-Schaltfläche** oder durch **Drücken der Enter-Taste** gesichert werden.
+- 🎨 **Dunkles Design passend zur Spieloberfläche**  
+  Sidebar und Buttons sind an den dunklen Look von Leitstellenspiel angelehnt.
 
 - 🧭 **Benutzerfreundliche Steuerung**  
   Ein Button in der unteren rechten Ecke öffnet oder schließt die Sidebar.
@@ -54,35 +50,21 @@ Es wird empfohlen, regelmäßig nach Updates zu schauen, um von den neuesten Ver
 
 ## ℹ️ Sonstige Informationen
 
-### 🧪 Aktueller Entwicklungsstand (v5.1.0)
+### 🧪 Aktueller Entwicklungsstand (v6.0.0)
 
-**Automatische Updates (v5.1.0):** Das Skript enthält jetzt `@updateURL`/`@downloadURL` im Header. Tampermonkey prüft damit selbstständig (Standardeinstellung: periodisch im Hintergrund), ob sich `@version` in der `main`-Branch-Datei erhöht hat, und installiert neue Versionen automatisch. Voraussetzungen dafür:
+**Wichtigste Erkenntnis:** Leitstellenspiel hat die Ausrücke-Verzögerung **bereits eingebaut** – als Feld auf der nativen „Fahrzeug bearbeiten“-Seite (`/vehicles/<id>/edit`). Die Versionen bis v5.x haben das nicht genutzt, sondern versucht, das Alarmieren selbst über einen abgefangenen Klick zu verzögern (clientseitiger Nachbau) bzw. den Wert nur lokal in `localStorage` zu speichern – beides ohne echten Effekt im Spiel.
 
-1. Änderungen müssen in den `main`-Branch des Repos gemergt sein (nicht nur in einen Feature-Branch) – nur davon liest Tampermonkey.
-2. In Tampermonkey unter *Einstellungen → Update* muss die automatische Update-Prüfung aktiviert sein (Standard: an).
-3. Nach dem Einspielen dieser Version einmalig das Skript neu installieren bzw. in Tampermonkey unter *Dashboard → Skript → Updates prüfen* einmal manuell aktualisieren, damit die neuen `@updateURL`-Angaben übernommen werden. Ab dann läuft es automatisch.
+Seit v6.0.0 schreibt das Skript stattdessen direkt in das native Feld:
 
-Der bisherige eigene Update-Check per `GM_xmlhttpRequest` wurde entfernt – er zeigte auf eine nicht existierende `version.txt` und hat nie funktioniert. `@updateURL`/`@downloadURL` sind der Standard-Mechanismus von Tampermonkey/Greasemonkey und robuster.
+1. Für jedes Fahrzeug der Wache wird die echte Bearbeiten-Seite im Hintergrund per `fetch` geladen und der aktuelle Wert aus dem Feld mit dem Label „Ausrücke-Verzögerung“ ausgelesen (nicht anhand eines geratenen Feldnamens, sondern über den sichtbaren Text).
+2. Beim Speichern wird nur für **geänderte** Fahrzeuge das komplette native Formular (inkl. CSRF-Token und allen anderen Feldern unverändert) mit dem neuen Wert erneut abgeschickt.
+3. Automatisiert gegen eine nachgebaute Kopie der echten Bearbeiten-Seite getestet: Lesen funktioniert, nur geänderte Fahrzeuge werden gespeichert, alle anderen Formularfelder bleiben nachweislich unangetastet.
 
-Leitstellenspiel kennt **serverseitig keine Ausrückverzögerung** – diese Funktion existiert im Spiel selbst nicht. Bis Version 3.1 hat das Skript die eingestellte Verzögerung nur in `localStorage` gespeichert, ohne dass sie irgendeinen Effekt im Spiel hatte.
+Damit entfällt der gesamte bisherige Klick-Interception-Mechanismus samt Countdown-Anzeige – nicht mehr nötig, da das Spiel die Verzögerung selbst korrekt umsetzt, sobald das native Feld gesetzt ist.
 
-**Wichtige Erkenntnis in v5.0.0:** Leitstellenspiel öffnet Wachen und Fahrzeuge als AJAX-Overlay, **ohne die Browser-URL zu wechseln**. Das Skript hat sich bis v4.1.0 auf `window.location.pathname` (`/buildings/123`) verlassen, das in der echten Spieloberfläche nie zutrifft – deshalb hat das Skript nie reagiert.
+**Frühere Erkenntnis (weiterhin relevant für die Wachen-Erkennung):** Leitstellenspiel öffnet Wachen als AJAX-Overlay, **ohne die Browser-URL zu wechseln**. Die aktuell angezeigte Wache wird daher über ihren sichtbaren Namen (Überschrift im Overlay) erkannt und mit `/api/buildings` bzw. `/api/vehicles` abgeglichen; ein `MutationObserver` beobachtet das Overlay laufend, da es ohne klassischen Seitenwechsel per AJAX nachlädt.
 
-Seit v5.0.0:
-
-- Die aktuell angezeigte Wache/das Fahrzeug wird über den **sichtbaren Namen** (Überschrift im Overlay) erkannt und mit `/api/buildings` bzw. `/api/vehicles` abgeglichen – unabhängig von der URL
-- Ein `MutationObserver` beobachtet das Overlay laufend, da es ohne klassischen Seitenwechsel per AJAX nachlädt
-- Der „Alarmieren“-Button wird über seinen sichtbaren Text erkannt (nicht mehr über einen geratenen Link-Aufbau)
-- `@match` gilt jetzt für die komplette Domain (`leitstellenspiel.de/*`), damit das Skript unabhängig vom Overlay-Zustand aktiv ist
-
-Außerdem wurde behoben:
-
-- Falscher API-Endpunkt (`/api/buildings/{id}/vehicles` existiert nicht) → jetzt `/api/vehicles` und `/api/buildings`
-- Versionsprüfung lief bei **jedem** Seitenaufruf gegen GitHub → jetzt auf alle 6 Stunden gedrosselt
-- Fehlende Fehlerrückmeldung im UI bei fehlgeschlagenem Laden der Fahrzeuge → sichtbare Toast-Meldungen
-- Bestehende Verzögerungen aus v3.1 werden beim ersten Start automatisch migriert
-
-⚠️ **Bekannte Einschränkung:** Die Erkennung basiert auf sichtbarem Text (Wachen-/Fahrzeugname, Button-Beschriftung „Alarmieren"). Weicht das Overlay strukturell stark ab, kann die Zuordnung fehlschlagen – dann greift keine Verzögerung, aber das Fahrzeug rückt wie gewohnt aus (kein Absturz). Zum Debuggen `window.__lssAvzDebug = true` in der Browser-Konsole setzen.
+⚠️ **Bekannte Einschränkung:** Die Erkennung des Verzögerungs-Feldes basiert auf dem sichtbaren Label-Text „Ausrücke-Verzögerung“. Ändert sich dieser Text im Spiel grundlegend, kann das Feld nicht gefunden werden – dann erscheint eine Fehlermeldung im Panel statt eines falschen Speicherversuchs. Zum Debuggen `window.__lssAvzDebug = true` in der Browser-Konsole setzen.
 
 🛠️ Rückmeldungen zum Live-Verhalten sind willkommen.
 


### PR DESCRIPTION
## Zusammenfassung

- Skript hat bis v5.x versucht, das Alarmieren clientseitig per Klick-Interception zu verzögern (bzw. davor gar nichts Wirksames getan). Erkenntnis aus Live-Tests: Leitstellenspiel hat eine **native "Ausrücke-Verzögerung"** pro Fahrzeug auf der Bearbeiten-Seite (`/vehicles/<id>/edit`) - das Skript schreibt jetzt direkt in dieses Feld, statt selbst etwas zu simulieren.
- Wachen-Erkennung läuft über den sichtbaren Namen im AJAX-Overlay (nicht über die URL, die sich im Spiel nie ändert) und wird per `MutationObserver` aktuell gehalten.
- Automatische Updates über `@updateURL`/`@downloadURL` (Tampermonkey-Bordmittel) statt eines nie funktionierenden Eigenbaus.
- Design an die tatsächlichen Leitstellenspiel-Farben angepasst (dunkles Grau, grüner Akzent statt Blau).
- Diverse Robustheit-/Sicherheitsfixes: korrekter API-Endpunkt, XSS-Vermeidung, sichtbare Fehler-/Status-Meldungen statt stiller Fehlschläge.

## Test plan

- [x] Automatisierter Playwright-Test gegen eine nachgebaute Kopie der echten "Fahrzeug bearbeiten"-Seite: Lesen der aktuellen Verzögerung, selektives Speichern nur geänderter Fahrzeuge, Erhalt aller anderen Formularfelder (Funkrufname, Personenanzahl) und des CSRF-Tokens
- [x] Live im Spiel getestet: Wache wird erkannt, Fahrzeugliste erscheint, native Werte werden korrekt geladen und gespeichert (Screenshots vom Nutzer bestätigt)
- [ ] Nach Merge: einmalig in Tampermonkey "Nach Updates suchen", damit die neuen `@updateURL`-Angaben übernommen werden

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BzPTnHVUL9ckNW5ixHvCjK)_